### PR TITLE
Modified ColorStyleNode and TextStyleNode Hasahble to avoid duplicated values

### DIFF
--- a/Sources/Fugen/Models/ColorStyle/ColorStyleNode.swift
+++ b/Sources/Fugen/Models/ColorStyle/ColorStyleNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct ColorStyleNode: Encodable, Hashable {
+struct ColorStyleNode: Encodable {
 
     // MARK: - Instance Properties
 
@@ -8,4 +8,15 @@ struct ColorStyleNode: Encodable, Hashable {
     let name: String
     let description: String?
     let color: Color
+}
+
+extension ColorStyleNode: Hashable {
+    static func == (lhs: ColorStyleNode, rhs: ColorStyleNode) -> Bool {
+        return lhs.name == rhs.name && lhs.color == rhs.color
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(color)
+    }
 }

--- a/Sources/Fugen/Models/TextStyle/TextStyleNode.swift
+++ b/Sources/Fugen/Models/TextStyle/TextStyleNode.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct TextStyleNode: Encodable, Hashable {
+struct TextStyleNode: Encodable {
 
     // MARK: - Instance Properties
 
@@ -14,4 +14,28 @@ struct TextStyleNode: Encodable, Hashable {
     let paragraphIndent: Double?
     let lineHeight: Double?
     let letterSpacing: Double?
+}
+
+extension TextStyleNode: Hashable {
+    static func == (lhs: TextStyleNode, rhs: TextStyleNode) -> Bool {
+        return lhs.name == rhs.name &&
+            lhs.font == rhs.font &&
+            lhs.strikethrough == rhs.strikethrough &&
+            lhs.underline == rhs.underline &&
+            lhs.paragraphSpacing == rhs.paragraphSpacing &&
+            lhs.paragraphIndent == rhs.paragraphIndent &&
+            lhs.lineHeight == rhs.lineHeight &&
+            lhs.letterSpacing == rhs.letterSpacing
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(font)
+        hasher.combine(strikethrough)
+        hasher.combine(underline)
+        hasher.combine(paragraphSpacing)
+        hasher.combine(paragraphIndent)
+        hasher.combine(lineHeight)
+        hasher.combine(letterSpacing)
+    }
 }


### PR DESCRIPTION
On larger projects when the same color or text style its used more than once in the node / file we was getting duplicated colors and text styles on generated ColorStyle.swift and TextStyle.swift.
I modified Hashable implementation to void `id` and `description` fields to get better definition of duplicated nodes