### PR TITLE
Added onlyExportables option for images export

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ The parameter can be skipped, if, for example, you only want to save assets.
 The default format is `pdf`.
 - `scales`: array with integer scaling factors from 1 to 3.
 The default scaling factor is 1, so the image will have the original size.
+- `onlyExportables`: Indicates if it will fetch only exportable components, `true` or `false`.
+The default value its `false`
 
 Sample configuration:
 ```yaml
@@ -369,6 +371,7 @@ images:
   file: https://www.figma.com/file/61xw2FQn61Xr7VVFYwiHHy/Fugen-Demo
   assets: Sources/Assets.xcassets/Images
   destination: Sources/Images.swift
+  onlyExportables: true
   templateOptions:
     publicAccess: true
 ```
@@ -377,6 +380,9 @@ images:
 Fugen only uses nodes that are [components](https://help.figma.com/article/66-components) as images.
 So, make sure that the chosen frame in the file URL (see [Figma file](#figma-file))
 allows to filter out the components that should not render images in Figma file.
+
+#### Only Exportables
+If this option is `true` only the component marked as exportable on figma will be render in file and assets.
 
 #### Xcode-assets
 It's recommended to specify the path to a subfolder inside the Xcode-assets folder in the `assets` parameter,

--- a/Sources/Fugen/Commands/ImagesCommand.swift
+++ b/Sources/Fugen/Commands/ImagesCommand.swift
@@ -116,6 +116,14 @@ final class ImagesCommand: AsyncExecutableCommand, GenerationConfigurableCommand
             """
     )
 
+    let onlyExportables = Key<Bool>(
+        "--onlyExportables",
+        description: """
+            Indicates if it will fetch only exportable components, true or false
+            By default false
+            """
+    )
+
     // MARK: - Initializers
 
     init(generator: ImagesGenerator) {
@@ -157,7 +165,8 @@ final class ImagesCommand: AsyncExecutableCommand, GenerationConfigurableCommand
             assets: assets.value,
             resources: resources.value,
             format: resolveImageFormat(),
-            scales: resolveImageScales()
+            scales: resolveImageScales(),
+            onlyExportables: onlyExportables.value ?? false
         )
     }
 

--- a/Sources/Fugen/Generators/Images/DefaultImagesGenerator.swift
+++ b/Sources/Fugen/Generators/Images/DefaultImagesGenerator.swift
@@ -55,6 +55,12 @@ private extension ImagesConfiguration {
     // MARK: - Instance Properties
 
     var imagesParameters: ImagesParameters {
-        ImagesParameters(format: format, scales: scales, assets: assets, resources: resources)
+        ImagesParameters(
+            format: format,
+            scales: scales,
+            assets: assets,
+            resources: resources,
+            onlyExportables: onlyExportables
+        )
     }
 }

--- a/Sources/Fugen/Models/Configuration/ImagesConfiguration.swift
+++ b/Sources/Fugen/Models/Configuration/ImagesConfiguration.swift
@@ -9,6 +9,7 @@ struct ImagesConfiguration: Decodable {
         case resources
         case format
         case scales
+        case onlyExportables
     }
 
     // MARK: - Instance Properties
@@ -18,6 +19,7 @@ struct ImagesConfiguration: Decodable {
     let resources: String?
     let format: ImageFormat
     let scales: [ImageScale]
+    let onlyExportables: Bool
 
     // MARK: - Initializers
 
@@ -26,13 +28,15 @@ struct ImagesConfiguration: Decodable {
         assets: String?,
         resources: String?,
         format: ImageFormat,
-        scales: [ImageScale]
+        scales: [ImageScale],
+        onlyExportables: Bool
     ) {
         self.generatation = generatation
         self.assets = assets
         self.resources = resources
         self.format = format
         self.scales = scales
+        self.onlyExportables = onlyExportables
     }
 
     init(from decoder: Decoder) throws {
@@ -43,7 +47,7 @@ struct ImagesConfiguration: Decodable {
 
         format = try container.decodeIfPresent(ImageFormat.self, forKey: .format) ?? .pdf
         scales = try container.decodeIfPresent([ImageScale].self, forKey: .scales) ?? [.none]
-
+        onlyExportables = try container.decodeIfPresent(Bool.self, forKey: .onlyExportables) ?? false
         generatation = try GenerationConfiguration(from: decoder)
     }
 
@@ -55,7 +59,8 @@ struct ImagesConfiguration: Decodable {
             assets: assets,
             resources: resources,
             format: format,
-            scales: scales
+            scales: scales,
+            onlyExportables: onlyExportables
         )
     }
 }

--- a/Sources/Fugen/Models/Parameters/ImagesParameters.swift
+++ b/Sources/Fugen/Models/Parameters/ImagesParameters.swift
@@ -8,4 +8,5 @@ struct ImagesParameters {
     let scales: [ImageScale]
     let assets: String?
     let resources: String?
+    let onlyExportables: Bool
 }


### PR DESCRIPTION
`onlyExportables` option will allow the user to choose to fetch all components or only those marked as exportable on Figma.
This way the designer will get the option to create components for design purpose only, and components used on the handoff to iOS.

Fugen images config will be like the follow:
```yaml
images:
  accessToken: 25961-4ac9fbc9-3bd8-4c43-bbe2-95e477f8a067
  file: https://www.figma.com/file/61xw2FQn61Xr7VVFYwiHHy/Fugen-Demo
  assets: Sources/Assets.xcassets/Images
  destination: Sources/Images.swift
  onlyExportables: true
  templateOptions:
    publicAccess: true
```
Fugen command line `images` will be like the follow:
```
Usage: fugen images [options]

Generates code for images from a Figma file.

Options:
  --accessToken <value>           A personal access token to make requests to the Figma API.
                                  Get more info: https://www.figma.com/developers/api#access-tokens
  --assets, -a <value>            Optional path to Xcode-assets folder to store images.
  --destination, -d <value>       The path to the file to generate.
                                  By default, generated code will be printed on stdout.
  --excludingNodes, -e <value>    A list of Figma nodes whose styles will be ignored.
                                  Can be repeated multiple times and must be in the format: -e "1:23".
  --fileKey <value>               Figma file key to generate images from.
  --fileVersion <value>           Figma file version ID to generate images from.
  --format, -r <value>            Optional image output format, can be 'pdf', 'png', 'jpg' or 'svg'.
                                  Defaults to 'pdf'.
  --includingNodes, -i <value>    A list of Figma nodes whose styles will be extracted.
                                  Can be repeated multiple times and must be in the format: -i "1:23".
                                  If omitted, all nodes will be included.
  --onlyExportables <value>       Indicates if it will fetch only exportable components, true or false
                                  By default false
  --options, -o <value>           An option that will be merged with template context, and overwrite any values of the same name.
                                  Can be repeated multiple times and must be in the format: -o "name:value".
  --resources, -r <value>         Optional path to Xcode-assets folder to store images.
  --template, -t <value>          Path to the template file.
                                  If no template is passed a default template will be used.
  -h, --help                      Show help information
  -scales, -s <value>             A comma separated list of integer image scaling factors.
                                  Each scaling factor should be between 1 and 3: -s "1,2,3".
                                  If omitted, images will be rendered with the original sizes.
```
