### PR TITLE
Generate text styles with using system font

### DIFF
--- a/Demo/.fugen.yml
+++ b/Demo/.fugen.yml
@@ -1,5 +1,5 @@
 base:
-  accessToken: 25961-4ac9fbc9-3bd8-4c43-bbe2-95e477f8a067
+  accessToken: 41151-2d41cf61-9835-402f-86fe-bbf6d8c3c480
 
 colorStyles:
   file: https://www.figma.com/file/61xw2FQn61Xr7VVFYwiHHy/Fugen-Demo?node-id=91%3A3
@@ -10,12 +10,13 @@ colorStyles:
 
 textStyles:
   file:
-    key: 61xw2FQn61Xr7VVFYwiHHy
+    key: OeN0WmQ5miixA849nZmcEN
     includedNodes:
       - 91%3A38
   destination: FugenDemo/Generated/TextStyle.swift
   templateOptions:
     publicAccess: true
+    usingSystemFonts: false
 
 images:
   file: https://www.figma.com/file/61xw2FQn61Xr7VVFYwiHHy/Fugen-Demo?node-id=91%3A63

--- a/Demo/.fugen.yml
+++ b/Demo/.fugen.yml
@@ -1,5 +1,5 @@
 base:
-  accessToken: 41151-2d41cf61-9835-402f-86fe-bbf6d8c3c480
+  accessToken: 25961-4ac9fbc9-3bd8-4c43-bbe2-95e477f8a067
 
 colorStyles:
   file: https://www.figma.com/file/61xw2FQn61Xr7VVFYwiHHy/Fugen-Demo?node-id=91%3A3
@@ -10,7 +10,7 @@ colorStyles:
 
 textStyles:
   file:
-    key: OeN0WmQ5miixA849nZmcEN
+    key: 61xw2FQn61Xr7VVFYwiHHy
     includedNodes:
       - 91%3A38
   destination: FugenDemo/Generated/TextStyle.swift

--- a/Demo/FugenDemo/Generated/TextStyle.swift
+++ b/Demo/FugenDemo/Generated/TextStyle.swift
@@ -154,27 +154,37 @@ public struct TextStyle: Equatable {
         letterSpacing: 0.1
     )
 
+    /// Big Header
+    ///
+    /// Font: Roboto (Roboto-Bold); weight 700.0; size 48.0
+    /// Color: Eclipse; hex #393939FF; rgba 57 57 57, 100%
+    /// Strikethrough: false
+    /// Underline: false
+    /// Paragraph spacing: default
+    /// Paragraph indent: default
+    /// Line height: 60.0
+    /// Letter spacing: 0.0
+    public static let bigHeader = TextStyle(
+        font: UIFont(name: "Roboto-Bold", size: 48.0),
+        color: UIColor(
+            red: 0.2235294133424759,
+            green: 0.2235294133424759,
+            blue: 0.2235294133424759,
+            alpha: 1.0
+        ),
+        strikethrough: false,
+        underline: false,
+        paragraphSpacing: nil,
+        paragraphIndent: nil,
+        lineHeight: 60.0,
+        letterSpacing: 0.0
+    )
+
     // MARK: - Type Methods
 
     public static func validate() throws {
-        guard UIFont(name: "SFProDisplay-Light", size: 13.0) != nil else {
-            throw ValidationError.fontNotFound(name: "SFProDisplay-Light", size: 13.0)
-        }
-
-        guard UIFont(name: "SFProDisplay-Regular", size: 13.0) != nil else {
-            throw ValidationError.fontNotFound(name: "SFProDisplay-Regular", size: 13.0)
-        }
-
-        guard UIFont(name: "SFProDisplay-Regular", size: 15.0) != nil else {
-            throw ValidationError.fontNotFound(name: "SFProDisplay-Regular", size: 15.0)
-        }
-
-        guard UIFont(name: "SFProDisplay-Medium", size: 17.0) != nil else {
-            throw ValidationError.fontNotFound(name: "SFProDisplay-Medium", size: 17.0)
-        }
-
-        guard UIFont(name: "SFProDisplay-Bold", size: 34.0) != nil else {
-            throw ValidationError.fontNotFound(name: "SFProDisplay-Bold", size: 34.0)
+        guard UIFont(name: "Roboto-Bold", size: 48.0) != nil else {
+            throw ValidationError.fontNotFound(name: "Roboto-Bold", size: 48.0)
         }
 
         print("All text styles are valid")

--- a/Demo/FugenDemo/Generated/TextStyle.swift
+++ b/Demo/FugenDemo/Generated/TextStyle.swift
@@ -154,37 +154,27 @@ public struct TextStyle: Equatable {
         letterSpacing: 0.1
     )
 
-    /// Big Header
-    ///
-    /// Font: Roboto (Roboto-Bold); weight 700.0; size 48.0
-    /// Color: Eclipse; hex #393939FF; rgba 57 57 57, 100%
-    /// Strikethrough: false
-    /// Underline: false
-    /// Paragraph spacing: default
-    /// Paragraph indent: default
-    /// Line height: 60.0
-    /// Letter spacing: 0.0
-    public static let bigHeader = TextStyle(
-        font: UIFont(name: "Roboto-Bold", size: 48.0),
-        color: UIColor(
-            red: 0.2235294133424759,
-            green: 0.2235294133424759,
-            blue: 0.2235294133424759,
-            alpha: 1.0
-        ),
-        strikethrough: false,
-        underline: false,
-        paragraphSpacing: nil,
-        paragraphIndent: nil,
-        lineHeight: 60.0,
-        letterSpacing: 0.0
-    )
-
     // MARK: - Type Methods
 
     public static func validate() throws {
-        guard UIFont(name: "Roboto-Bold", size: 48.0) != nil else {
-            throw ValidationError.fontNotFound(name: "Roboto-Bold", size: 48.0)
+        guard UIFont(name: "SFProDisplay-Light", size: 13.0) != nil else {
+            throw ValidationError.fontNotFound(name: "SFProDisplay-Light", size: 13.0)
+        }
+
+        guard UIFont(name: "SFProDisplay-Regular", size: 13.0) != nil else {
+            throw ValidationError.fontNotFound(name: "SFProDisplay-Regular", size: 13.0)
+        }
+
+        guard UIFont(name: "SFProDisplay-Regular", size: 15.0) != nil else {
+            throw ValidationError.fontNotFound(name: "SFProDisplay-Regular", size: 15.0)
+        }
+
+        guard UIFont(name: "SFProDisplay-Medium", size: 17.0) != nil else {
+            throw ValidationError.fontNotFound(name: "SFProDisplay-Medium", size: 17.0)
+        }
+
+        guard UIFont(name: "SFProDisplay-Bold", size: 34.0) != nil else {
+            throw ValidationError.fontNotFound(name: "SFProDisplay-Bold", size: 34.0)
         }
 
         print("All text styles are valid")

--- a/Fugen.xcodeproj/project.pbxproj
+++ b/Fugen.xcodeproj/project.pbxproj
@@ -2178,7 +2178,7 @@
 			path = .build/checkouts/SwiftCLI/Sources/SwiftCLI;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -2200,7 +2200,6 @@
 				OBJ_525 /* Brewfile */,
 				OBJ_526 /* Fugen.podspec */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_500 /* Products */ = {
@@ -2449,6 +2448,7 @@
 			buildPhases = (
 				OBJ_584 /* Sources */,
 				OBJ_763 /* Frameworks */,
+				8EAF8CA325624F5B004F21D7 /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -2796,7 +2796,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_500 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -2828,6 +2828,27 @@
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		8EAF8CA325624F5B004F21D7 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "sh Scripts/swiftlint.sh\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		OBJ_1013 /* Sources */ = {

--- a/Fugen.xcodeproj/project.pbxproj
+++ b/Fugen.xcodeproj/project.pbxproj
@@ -9,23 +9,23 @@
 /* Begin PBXAggregateTarget section */
 		"Fugen::FugenPackageTests::ProductTarget" /* FugenPackageTests */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = OBJ_790 /* Build configuration list for PBXAggregateTarget "FugenPackageTests" */;
+			buildConfigurationList = OBJ_799 /* Build configuration list for PBXAggregateTarget "FugenPackageTests" */;
 			buildPhases = (
 			);
 			dependencies = (
-				OBJ_793 /* PBXTargetDependency */,
-				OBJ_795 /* PBXTargetDependency */,
+				OBJ_802 /* PBXTargetDependency */,
+				OBJ_804 /* PBXTargetDependency */,
 			);
 			name = FugenPackageTests;
 			productName = FugenPackageTests;
 		};
 		"Fugen::fugen::ProductTarget" /* fugen */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = OBJ_1128 /* Build configuration list for PBXAggregateTarget "fugen" */;
+			buildConfigurationList = OBJ_1137 /* Build configuration list for PBXAggregateTarget "fugen" */;
 			buildPhases = (
 			);
 			dependencies = (
-				OBJ_1131 /* PBXTargetDependency */,
+				OBJ_1140 /* PBXTargetDependency */,
 			);
 			name = fugen;
 			productName = fugen;
@@ -33,695 +33,700 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		C01B801C24FFF7D00080227E /* ShadowType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C01B801A24FFF78B0080227E /* ShadowType.swift */; };
-		C0BE783524E94735004EBBEF /* Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BE783424E94735004EBBEF /* Shadow.swift */; };
-		C0BE783724E95650004EBBEF /* TextStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BE783624E95650004EBBEF /* TextStyle.swift */; };
-		C0BE783C24E9B26E004EBBEF /* StencilVectorFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BE783B24E9B26E004EBBEF /* StencilVectorFilter.swift */; };
-		C0BE783E24E9B2E8004EBBEF /* StencilVectorInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0BE783D24E9B2E8004EBBEF /* StencilVectorInfoFilter.swift */; };
-		OBJ_1005 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_458 /* Package.swift */; };
-		OBJ_1010 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_404 /* Context.swift */; };
-		OBJ_1011 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_405 /* Environment.swift */; };
-		OBJ_1012 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_406 /* Errors.swift */; };
-		OBJ_1013 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_407 /* Expression.swift */; };
-		OBJ_1014 /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_408 /* Extension.swift */; };
-		OBJ_1015 /* FilterTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_409 /* FilterTag.swift */; };
-		OBJ_1016 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_410 /* Filters.swift */; };
-		OBJ_1017 /* ForTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_411 /* ForTag.swift */; };
-		OBJ_1018 /* IfTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_412 /* IfTag.swift */; };
-		OBJ_1019 /* Include.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_413 /* Include.swift */; };
-		OBJ_1020 /* Inheritence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_414 /* Inheritence.swift */; };
-		OBJ_1021 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_415 /* KeyPath.swift */; };
-		OBJ_1022 /* Lexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_416 /* Lexer.swift */; };
-		OBJ_1023 /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_417 /* Loader.swift */; };
-		OBJ_1024 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_418 /* Node.swift */; };
-		OBJ_1025 /* NowTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_419 /* NowTag.swift */; };
-		OBJ_1026 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_420 /* Parser.swift */; };
-		OBJ_1027 /* Template.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_421 /* Template.swift */; };
-		OBJ_1028 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_422 /* Tokenizer.swift */; };
-		OBJ_1029 /* Variable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_423 /* Variable.swift */; };
-		OBJ_1031 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PathKit::PathKit::Product" /* PathKit.framework */; };
-		OBJ_1038 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_403 /* Package.swift */; };
-		OBJ_1043 /* CallMacroNodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_390 /* CallMacroNodes.swift */; };
-		OBJ_1044 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_391 /* Context.swift */; };
-		OBJ_1045 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_392 /* Environment.swift */; };
-		OBJ_1046 /* Filters+Numbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_393 /* Filters+Numbers.swift */; };
-		OBJ_1047 /* Filters+Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_394 /* Filters+Strings.swift */; };
-		OBJ_1048 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_395 /* Filters.swift */; };
-		OBJ_1049 /* MapNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_396 /* MapNode.swift */; };
-		OBJ_1050 /* Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_397 /* Parameters.swift */; };
-		OBJ_1051 /* SetNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_398 /* SetNode.swift */; };
-		OBJ_1052 /* StencilSwiftTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_399 /* StencilSwiftTemplate.swift */; };
-		OBJ_1053 /* SwiftIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_400 /* SwiftIdentifier.swift */; };
-		OBJ_1055 /* Stencil.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Stencil::Stencil::Product" /* Stencil.framework */; };
-		OBJ_1056 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PathKit::PathKit::Product" /* PathKit.framework */; };
-		OBJ_1064 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_401 /* Package.swift */; };
-		OBJ_1069 /* ArgumentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_472 /* ArgumentList.swift */; };
-		OBJ_1070 /* ArgumentListManipulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_473 /* ArgumentListManipulator.swift */; };
-		OBJ_1071 /* CLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_474 /* CLI.swift */; };
-		OBJ_1072 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_475 /* Command.swift */; };
-		OBJ_1073 /* Compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_476 /* Compatibility.swift */; };
-		OBJ_1074 /* CompletionGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_477 /* CompletionGenerator.swift */; };
-		OBJ_1075 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_478 /* Error.swift */; };
-		OBJ_1076 /* HelpCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_479 /* HelpCommand.swift */; };
-		OBJ_1077 /* HelpMessageGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_480 /* HelpMessageGenerator.swift */; };
-		OBJ_1078 /* Input.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_481 /* Input.swift */; };
-		OBJ_1079 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_482 /* Option.swift */; };
-		OBJ_1080 /* OptionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_483 /* OptionGroup.swift */; };
-		OBJ_1081 /* OptionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_484 /* OptionRegistry.swift */; };
-		OBJ_1082 /* Parameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_485 /* Parameter.swift */; };
-		OBJ_1083 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_486 /* Parser.swift */; };
-		OBJ_1084 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_487 /* Path.swift */; };
-		OBJ_1085 /* Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_488 /* Stream.swift */; };
-		OBJ_1086 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_489 /* Task.swift */; };
-		OBJ_1087 /* Term.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_490 /* Term.swift */; };
-		OBJ_1088 /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_491 /* Validation.swift */; };
-		OBJ_1089 /* ValueBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_492 /* ValueBox.swift */; };
-		OBJ_1090 /* VersionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_493 /* VersionCommand.swift */; };
-		OBJ_1097 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_494 /* Package.swift */; };
-		OBJ_1102 /* Constructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_440 /* Constructor.swift */; };
-		OBJ_1103 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_441 /* Decoder.swift */; };
-		OBJ_1104 /* Emitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_442 /* Emitter.swift */; };
-		OBJ_1105 /* Encoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_443 /* Encoder.swift */; };
-		OBJ_1106 /* Mark.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_444 /* Mark.swift */; };
-		OBJ_1107 /* Node.Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_445 /* Node.Mapping.swift */; };
-		OBJ_1108 /* Node.Scalar.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_446 /* Node.Scalar.swift */; };
-		OBJ_1109 /* Node.Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_447 /* Node.Sequence.swift */; };
-		OBJ_1110 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_448 /* Node.swift */; };
-		OBJ_1111 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_449 /* Parser.swift */; };
-		OBJ_1112 /* Representer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_450 /* Representer.swift */; };
-		OBJ_1113 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_451 /* Resolver.swift */; };
-		OBJ_1114 /* String+Yams.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_452 /* String+Yams.swift */; };
-		OBJ_1115 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_453 /* Tag.swift */; };
-		OBJ_1116 /* YamlError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_454 /* YamlError.swift */; };
-		OBJ_1117 /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_455 /* shim.swift */; };
-		OBJ_1119 /* CYaml.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::CYaml::Product" /* CYaml.framework */; };
-		OBJ_1126 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_456 /* Package.swift */; };
-		OBJ_527 /* api.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_430 /* api.c */; };
-		OBJ_528 /* emitter.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_431 /* emitter.c */; };
-		OBJ_529 /* parser.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_432 /* parser.c */; };
-		OBJ_530 /* reader.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_433 /* reader.c */; };
-		OBJ_531 /* scanner.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_434 /* scanner.c */; };
-		OBJ_532 /* writer.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_435 /* writer.c */; };
-		OBJ_534 /* CYaml.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_437 /* CYaml.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		OBJ_535 /* yaml.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_438 /* yaml.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		OBJ_542 /* DictionaryComponentDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_341 /* DictionaryComponentDecoder.swift */; };
-		OBJ_543 /* DictionaryDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_342 /* DictionaryDecoder.swift */; };
-		OBJ_544 /* DictionaryDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_343 /* DictionaryDecodingOptions.swift */; };
-		OBJ_545 /* DictionaryKeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_344 /* DictionaryKeyedDecodingContainer.swift */; };
-		OBJ_546 /* DictionarySingleValueDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_345 /* DictionarySingleValueDecodingContainer.swift */; };
-		OBJ_547 /* DictionaryUnkeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_346 /* DictionaryUnkeyedDecodingContainer.swift */; };
-		OBJ_548 /* DictionaryDataDecodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_348 /* DictionaryDataDecodingStrategy.swift */; };
-		OBJ_549 /* DictionaryDateDecodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_349 /* DictionaryDateDecodingStrategy.swift */; };
-		OBJ_550 /* DictionaryKeyDecodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_350 /* DictionaryKeyDecodingStrategy.swift */; };
-		OBJ_551 /* DictionaryNonConformingFloatDecodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_351 /* DictionaryNonConformingFloatDecodingStrategy.swift */; };
-		OBJ_552 /* DictionaryAnyKeyedEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_353 /* DictionaryAnyKeyedEncodingContainer.swift */; };
-		OBJ_553 /* DictionaryComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_354 /* DictionaryComponent.swift */; };
-		OBJ_554 /* DictionaryComponentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_355 /* DictionaryComponentContainer.swift */; };
-		OBJ_555 /* DictionaryComponentEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_356 /* DictionaryComponentEncoder.swift */; };
-		OBJ_556 /* DictionaryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_357 /* DictionaryEncoder.swift */; };
-		OBJ_557 /* DictionaryEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_358 /* DictionaryEncodingOptions.swift */; };
-		OBJ_558 /* DictionaryKeyedEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_359 /* DictionaryKeyedEncodingContainer.swift */; };
-		OBJ_559 /* DictionarySingleValueEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_360 /* DictionarySingleValueEncodingContainer.swift */; };
-		OBJ_560 /* DictionaryUnkeyedEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_361 /* DictionaryUnkeyedEncodingContainer.swift */; };
-		OBJ_561 /* DictionaryDataEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_363 /* DictionaryDataEncodingStrategy.swift */; };
-		OBJ_562 /* DictionaryDateEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_364 /* DictionaryDateEncodingStrategy.swift */; };
-		OBJ_563 /* DictionaryKeyEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_365 /* DictionaryKeyEncodingStrategy.swift */; };
-		OBJ_564 /* DictionaryNonConformingFloatEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_366 /* DictionaryNonConformingFloatEncodingStrategy.swift */; };
-		OBJ_565 /* AnyCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_368 /* AnyCodingKey.swift */; };
-		OBJ_566 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_369 /* Optional+Extensions.swift */; };
-		OBJ_567 /* RangeReplaceableCollection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_370 /* RangeReplaceableCollection+Extensions.swift */; };
-		OBJ_574 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_339 /* Package.swift */; };
-		OBJ_580 /* AsyncExecutableCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* AsyncExecutableCommand.swift */; };
-		OBJ_581 /* ColorStylesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* ColorStylesCommand.swift */; };
-		OBJ_582 /* GenerateCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* GenerateCommand.swift */; };
-		OBJ_583 /* GenerationConfigurableCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* GenerationConfigurableCommand.swift */; };
-		OBJ_584 /* ImagesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* ImagesCommand.swift */; };
-		OBJ_585 /* ShadowStylesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* ShadowStylesCommand.swift */; };
-		OBJ_586 /* TextStylesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* TextStylesCommand.swift */; };
-		OBJ_587 /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* Dependencies.swift */; };
-		OBJ_588 /* ColorStylesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* ColorStylesContext.swift */; };
-		OBJ_589 /* ColorStylesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* ColorStylesGenerator.swift */; };
-		OBJ_590 /* DefaultColorStylesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* DefaultColorStylesGenerator.swift */; };
-		OBJ_591 /* GenerationParametersError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* GenerationParametersError.swift */; };
-		OBJ_592 /* GenerationParametersResolving.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* GenerationParametersResolving.swift */; };
-		OBJ_593 /* DefaultImagesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* DefaultImagesGenerator.swift */; };
-		OBJ_594 /* ImagesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* ImagesContext.swift */; };
-		OBJ_595 /* ImagesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* ImagesGenerator.swift */; };
-		OBJ_596 /* DefaultLibraryGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* DefaultLibraryGenerator.swift */; };
-		OBJ_597 /* LibraryGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* LibraryGenerator.swift */; };
-		OBJ_598 /* DefaultShadowStylesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* DefaultShadowStylesGenerator.swift */; };
-		OBJ_599 /* ShadowStylesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* ShadowStylesContext.swift */; };
-		OBJ_600 /* ShadowStylesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* ShadowStylesGenerator.swift */; };
-		OBJ_601 /* DefaultTextStylesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* DefaultTextStylesGenerator.swift */; };
-		OBJ_602 /* TextStylesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* TextStylesContext.swift */; };
-		OBJ_603 /* TextStylesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* TextStylesGenerator.swift */; };
-		OBJ_604 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* Color.swift */; };
-		OBJ_605 /* ColorStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* ColorStyle.swift */; };
-		OBJ_606 /* ColorStyleAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* ColorStyleAsset.swift */; };
-		OBJ_607 /* ColorStyleNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_45 /* ColorStyleNode.swift */; };
-		OBJ_608 /* AccessTokenConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_47 /* AccessTokenConfiguration.swift */; };
-		OBJ_609 /* BaseConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_48 /* BaseConfiguration.swift */; };
-		OBJ_610 /* ColorStylesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_49 /* ColorStylesConfiguration.swift */; };
-		OBJ_611 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_50 /* Configuration.swift */; };
-		OBJ_612 /* FileConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_51 /* FileConfiguration.swift */; };
-		OBJ_613 /* GenerationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_52 /* GenerationConfiguration.swift */; };
-		OBJ_614 /* ImagesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_53 /* ImagesConfiguration.swift */; };
-		OBJ_615 /* ShadowStylesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_54 /* ShadowStylesConfiguration.swift */; };
-		OBJ_616 /* TextStylesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_55 /* TextStylesConfiguration.swift */; };
-		OBJ_617 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_56 /* Font.swift */; };
-		OBJ_618 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_58 /* Image.swift */; };
-		OBJ_619 /* ImageAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_59 /* ImageAsset.swift */; };
-		OBJ_620 /* ImageFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_60 /* ImageFormat.swift */; };
-		OBJ_621 /* ImageNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_61 /* ImageNode.swift */; };
-		OBJ_622 /* ImageRenderedNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_62 /* ImageRenderedNode.swift */; };
-		OBJ_623 /* ImageResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_63 /* ImageResource.swift */; };
-		OBJ_624 /* ImageScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_64 /* ImageScale.swift */; };
-		OBJ_625 /* FileParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_66 /* FileParameters.swift */; };
-		OBJ_626 /* GenerationParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_67 /* GenerationParameters.swift */; };
-		OBJ_627 /* ImagesParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_68 /* ImagesParameters.swift */; };
-		OBJ_628 /* NodesParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_69 /* NodesParameters.swift */; };
-		OBJ_629 /* RenderParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_70 /* RenderParameters.swift */; };
-		OBJ_630 /* ShadowStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_72 /* ShadowStyle.swift */; };
-		OBJ_631 /* ShadowStyleNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* ShadowStyleNode.swift */; };
-		OBJ_633 /* TextStyleColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_76 /* TextStyleColor.swift */; };
-		OBJ_634 /* TextStyleNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_77 /* TextStyleNode.swift */; };
-		OBJ_635 /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_78 /* Vector.swift */; };
-		OBJ_636 /* AssetsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_81 /* AssetsProvider.swift */; };
-		OBJ_637 /* DefaultAssetsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_82 /* DefaultAssetsProvider.swift */; };
-		OBJ_638 /* ColorStyleAssetsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_85 /* ColorStyleAssetsProvider.swift */; };
-		OBJ_639 /* DefaultColorStyleAssetsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_86 /* DefaultColorStyleAssetsProvider.swift */; };
-		OBJ_640 /* ColorStylesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_87 /* ColorStylesProvider.swift */; };
-		OBJ_641 /* ColorStylesProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_88 /* ColorStylesProviderError.swift */; };
-		OBJ_642 /* DefaultColorStylesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_89 /* DefaultColorStylesProvider.swift */; };
-		OBJ_643 /* ConfigurationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_91 /* ConfigurationProvider.swift */; };
-		OBJ_644 /* DefaultConfigurationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_92 /* DefaultConfigurationProvider.swift */; };
-		OBJ_645 /* DataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_94 /* DataProvider.swift */; };
-		OBJ_646 /* DefaultDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_95 /* DefaultDataProvider.swift */; };
-		OBJ_647 /* FigmaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_98 /* FigmaError.swift */; };
-		OBJ_648 /* FigmaImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_99 /* FigmaImages.swift */; };
-		OBJ_649 /* FigmaBlendMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_101 /* FigmaBlendMode.swift */; };
-		OBJ_650 /* FigmaBooleanOperationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_102 /* FigmaBooleanOperationType.swift */; };
-		OBJ_651 /* FigmaColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_103 /* FigmaColor.swift */; };
-		OBJ_652 /* FigmaColorStop.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_104 /* FigmaColorStop.swift */; };
-		OBJ_653 /* FigmaComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_105 /* FigmaComponent.swift */; };
-		OBJ_654 /* FigmaConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_106 /* FigmaConstraint.swift */; };
-		OBJ_655 /* FigmaConstraintType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_107 /* FigmaConstraintType.swift */; };
-		OBJ_656 /* FigmaEasingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_108 /* FigmaEasingType.swift */; };
-		OBJ_657 /* FigmaEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_109 /* FigmaEffect.swift */; };
-		OBJ_658 /* FigmaEffectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_110 /* FigmaEffectType.swift */; };
-		OBJ_659 /* FigmaExportSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_111 /* FigmaExportSetting.swift */; };
-		OBJ_660 /* FigmaFrameOffset.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_112 /* FigmaFrameOffset.swift */; };
-		OBJ_661 /* FigmaImageFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_113 /* FigmaImageFormat.swift */; };
-		OBJ_662 /* FigmaLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_114 /* FigmaLayoutConstraint.swift */; };
-		OBJ_663 /* FigmaLayoutGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_115 /* FigmaLayoutGrid.swift */; };
-		OBJ_664 /* FigmaLayoutGridAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_116 /* FigmaLayoutGridAlignment.swift */; };
-		OBJ_665 /* FigmaLayoutGridPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_117 /* FigmaLayoutGridPattern.swift */; };
-		OBJ_666 /* FigmaLayoutHorizontalConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_118 /* FigmaLayoutHorizontalConstraint.swift */; };
-		OBJ_667 /* FigmaLayoutVerticalConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_119 /* FigmaLayoutVerticalConstraint.swift */; };
-		OBJ_668 /* FigmaLineHeightUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_120 /* FigmaLineHeightUnit.swift */; };
-		OBJ_669 /* FigmaPaint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_121 /* FigmaPaint.swift */; };
-		OBJ_670 /* FigmaPaintType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_122 /* FigmaPaintType.swift */; };
-		OBJ_671 /* FigmaRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_123 /* FigmaRectangle.swift */; };
-		OBJ_672 /* FigmaScaleMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_124 /* FigmaScaleMode.swift */; };
-		OBJ_673 /* FigmaStrokeAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_125 /* FigmaStrokeAlignment.swift */; };
-		OBJ_674 /* FigmaStrokeCap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_126 /* FigmaStrokeCap.swift */; };
-		OBJ_675 /* FigmaStrokeJoin.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_127 /* FigmaStrokeJoin.swift */; };
-		OBJ_676 /* FigmaStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_128 /* FigmaStyle.swift */; };
-		OBJ_677 /* FigmaStyleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_129 /* FigmaStyleType.swift */; };
-		OBJ_678 /* FigmaTextCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_130 /* FigmaTextCase.swift */; };
-		OBJ_679 /* FigmaTextDecoration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_131 /* FigmaTextDecoration.swift */; };
-		OBJ_680 /* FigmaTextHorizontalAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_132 /* FigmaTextHorizontalAlignment.swift */; };
-		OBJ_681 /* FigmaTextVerticalAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_133 /* FigmaTextVerticalAlignment.swift */; };
-		OBJ_682 /* FigmaTypeStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_134 /* FigmaTypeStyle.swift */; };
-		OBJ_683 /* FigmaVector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_135 /* FigmaVector.swift */; };
-		OBJ_684 /* FigmaBooleanOperationNodePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_137 /* FigmaBooleanOperationNodePayload.swift */; };
-		OBJ_685 /* FigmaCanvasNodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_138 /* FigmaCanvasNodeInfo.swift */; };
-		OBJ_686 /* FigmaDocumentNodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_139 /* FigmaDocumentNodeInfo.swift */; };
-		OBJ_687 /* FigmaFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_140 /* FigmaFile.swift */; };
-		OBJ_688 /* FigmaFrameNodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_141 /* FigmaFrameNodeInfo.swift */; };
-		OBJ_689 /* FigmaInstanceNodePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_142 /* FigmaInstanceNodePayload.swift */; };
-		OBJ_690 /* FigmaNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_143 /* FigmaNode.swift */; };
-		OBJ_691 /* FigmaNodeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_144 /* FigmaNodeType.swift */; };
-		OBJ_692 /* FigmaRectangleNodePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_145 /* FigmaRectangleNodePayload.swift */; };
-		OBJ_693 /* FigmaSliceNodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_146 /* FigmaSliceNodeInfo.swift */; };
-		OBJ_694 /* FigmaTextNodePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_147 /* FigmaTextNodePayload.swift */; };
-		OBJ_695 /* FigmaVectorNodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_148 /* FigmaVectorNodeInfo.swift */; };
-		OBJ_696 /* DefaultFigmaAPIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_149 /* DefaultFigmaAPIProvider.swift */; };
-		OBJ_697 /* FigmaAPIEmptyParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_150 /* FigmaAPIEmptyParameters.swift */; };
-		OBJ_698 /* FigmaAPIEmptyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_151 /* FigmaAPIEmptyResponse.swift */; };
-		OBJ_699 /* FigmaAPIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_152 /* FigmaAPIProvider.swift */; };
-		OBJ_700 /* FigmaAPIRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_153 /* FigmaAPIRoute.swift */; };
-		OBJ_701 /* FigmaAPIVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_154 /* FigmaAPIVersion.swift */; };
-		OBJ_702 /* FigmaHTTPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_155 /* FigmaHTTPService.swift */; };
-		OBJ_703 /* FigmaAPIFileRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_157 /* FigmaAPIFileRoute.swift */; };
-		OBJ_704 /* FigmaAPIFileRouteQueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_158 /* FigmaAPIFileRouteQueryParameters.swift */; };
-		OBJ_705 /* FigmaAPIImagesRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_159 /* FigmaAPIImagesRoute.swift */; };
-		OBJ_706 /* FigmaAPIImagesRouteQueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_160 /* FigmaAPIImagesRouteQueryParameters.swift */; };
-		OBJ_707 /* DefaultFigmaFilesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_162 /* DefaultFigmaFilesProvider.swift */; };
-		OBJ_708 /* FigmaFilesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_163 /* FigmaFilesProvider.swift */; };
-		OBJ_709 /* DefaultFigmaNodesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_165 /* DefaultFigmaNodesProvider.swift */; };
-		OBJ_710 /* FigmaNodesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_166 /* FigmaNodesProvider.swift */; };
-		OBJ_711 /* FigmaNodesProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_167 /* FigmaNodesProviderError.swift */; };
-		OBJ_712 /* DefaultImageAssetsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_170 /* DefaultImageAssetsProvider.swift */; };
-		OBJ_713 /* ImageAssetsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_171 /* ImageAssetsProvider.swift */; };
-		OBJ_714 /* DefaultImagesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_172 /* DefaultImagesProvider.swift */; };
-		OBJ_715 /* ImagesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_173 /* ImagesProvider.swift */; };
-		OBJ_716 /* ImagesProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_174 /* ImagesProviderError.swift */; };
-		OBJ_717 /* DefaultImageRenderProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_176 /* DefaultImageRenderProvider.swift */; };
-		OBJ_718 /* ImageRenderProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_177 /* ImageRenderProvider.swift */; };
-		OBJ_719 /* ImageRenderProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_178 /* ImageRenderProviderError.swift */; };
-		OBJ_720 /* DefaultImageResourcesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_180 /* DefaultImageResourcesProvider.swift */; };
-		OBJ_721 /* ImageResourcesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_181 /* ImageResourcesProvider.swift */; };
-		OBJ_722 /* DefaultShadowStylesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_183 /* DefaultShadowStylesProvider.swift */; };
-		OBJ_723 /* ShadowStylesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_184 /* ShadowStylesProvider.swift */; };
-		OBJ_724 /* ShadowStylesProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_185 /* ShadowStylesProviderError.swift */; };
-		OBJ_725 /* DefaultTextStylesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_187 /* DefaultTextStylesProvider.swift */; };
-		OBJ_726 /* TextStylesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_188 /* TextStylesProvider.swift */; };
-		OBJ_727 /* TextStylesProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_189 /* TextStylesProviderError.swift */; };
-		OBJ_728 /* DefaultTemplateContextCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_191 /* DefaultTemplateContextCoder.swift */; };
-		OBJ_729 /* DefaultTemplateRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_192 /* DefaultTemplateRenderer.swift */; };
-		OBJ_730 /* RenderDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_193 /* RenderDestination.swift */; };
-		OBJ_731 /* RenderTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_194 /* RenderTemplate.swift */; };
-		OBJ_732 /* RenderTemplateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_195 /* RenderTemplateType.swift */; };
-		OBJ_733 /* StencilColorFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_198 /* StencilColorFilter.swift */; };
-		OBJ_734 /* StencilColorInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_199 /* StencilColorInfoFilter.swift */; };
-		OBJ_735 /* StencilColorRGBAHexInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_200 /* StencilColorRGBAHexInfoFilter.swift */; };
-		OBJ_736 /* StencilColorRGBAInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_201 /* StencilColorRGBAInfoFilter.swift */; };
-		OBJ_737 /* StencilColorRGBHexInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_202 /* StencilColorRGBHexInfoFilter.swift */; };
-		OBJ_738 /* StencilColorRGBInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_203 /* StencilColorRGBInfoFilter.swift */; };
-		OBJ_739 /* StencilFontFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_205 /* StencilFontFilter.swift */; };
-		OBJ_740 /* StencilFontInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_206 /* StencilFontInfoFilter.swift */; };
-		OBJ_741 /* StencilByteToFloatFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_208 /* StencilByteToFloatFilter.swift */; };
-		OBJ_742 /* StencilByteToHexFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_209 /* StencilByteToHexFilter.swift */; };
-		OBJ_743 /* StencilFloatToByteFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_210 /* StencilFloatToByteFilter.swift */; };
-		OBJ_744 /* StencilHexToByteFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_211 /* StencilHexToByteFilter.swift */; };
-		OBJ_745 /* StencilExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_212 /* StencilExtension.swift */; };
-		OBJ_746 /* StencilFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_213 /* StencilFilter.swift */; };
-		OBJ_747 /* StencilFilterError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_214 /* StencilFilterError.swift */; };
-		OBJ_748 /* StencilTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_215 /* StencilTag.swift */; };
-		OBJ_749 /* StencilTagError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_216 /* StencilTagError.swift */; };
-		OBJ_750 /* StencilTagNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_217 /* StencilTagNode.swift */; };
-		OBJ_751 /* TemplateContextCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_218 /* TemplateContextCoder.swift */; };
-		OBJ_752 /* TemplateRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_219 /* TemplateRenderer.swift */; };
-		OBJ_753 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_220 /* main.swift */; };
-		OBJ_755 /* DictionaryCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "DictionaryCoder::DictionaryCoder::Product" /* DictionaryCoder.framework */; };
-		OBJ_756 /* StencilSwiftKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "StencilSwiftKit::StencilSwiftKit::Product" /* StencilSwiftKit.framework */; };
-		OBJ_757 /* Stencil.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Stencil::Stencil::Product" /* Stencil.framework */; };
-		OBJ_758 /* Rainbow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Rainbow::Rainbow::Product" /* Rainbow.framework */; };
-		OBJ_759 /* Yams.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::Yams::Product" /* Yams.framework */; };
-		OBJ_760 /* CYaml.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::CYaml::Product" /* CYaml.framework */; };
-		OBJ_761 /* FugenTools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Fugen::FugenTools::Product" /* FugenTools.framework */; };
-		OBJ_762 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PromiseKit::PromiseKit::Product" /* PromiseKit.framework */; };
-		OBJ_763 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PathKit::PathKit::Product" /* PathKit.framework */; };
-		OBJ_764 /* SwiftCLI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftCLI::SwiftCLI::Product" /* SwiftCLI.framework */; };
-		OBJ_788 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
-		OBJ_801 /* FugenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_331 /* FugenTests.swift */; };
-		OBJ_802 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_332 /* XCTestManifests.swift */; };
-		OBJ_804 /* DictionaryCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "DictionaryCoder::DictionaryCoder::Product" /* DictionaryCoder.framework */; };
-		OBJ_805 /* StencilSwiftKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "StencilSwiftKit::StencilSwiftKit::Product" /* StencilSwiftKit.framework */; };
-		OBJ_806 /* Stencil.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Stencil::Stencil::Product" /* Stencil.framework */; };
-		OBJ_807 /* Rainbow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Rainbow::Rainbow::Product" /* Rainbow.framework */; };
-		OBJ_808 /* Yams.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::Yams::Product" /* Yams.framework */; };
-		OBJ_809 /* CYaml.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::CYaml::Product" /* CYaml.framework */; };
-		OBJ_810 /* FugenTools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Fugen::FugenTools::Product" /* FugenTools.framework */; };
-		OBJ_811 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PromiseKit::PromiseKit::Product" /* PromiseKit.framework */; };
-		OBJ_812 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PathKit::PathKit::Product" /* PathKit.framework */; };
-		OBJ_813 /* SwiftCLI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftCLI::SwiftCLI::Product" /* SwiftCLI.framework */; };
-		OBJ_829 /* AssetAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_223 /* AssetAppearance.swift */; };
-		OBJ_830 /* AssetAppearanceContrast.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_224 /* AssetAppearanceContrast.swift */; };
-		OBJ_831 /* AssetAppearanceLuminosity.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_225 /* AssetAppearanceLuminosity.swift */; };
-		OBJ_832 /* AssetCompressionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_226 /* AssetCompressionType.swift */; };
-		OBJ_833 /* AssetDisplayGamut.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_227 /* AssetDisplayGamut.swift */; };
-		OBJ_834 /* AssetIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_228 /* AssetIdiom.swift */; };
-		OBJ_835 /* AssetIdiomIPadSubtype.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_229 /* AssetIdiomIPadSubtype.swift */; };
-		OBJ_836 /* AssetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_230 /* AssetInfo.swift */; };
-		OBJ_837 /* AssetNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_231 /* AssetNode.swift */; };
-		OBJ_838 /* AssetColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_233 /* AssetColor.swift */; };
-		OBJ_839 /* AssetColorComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_234 /* AssetColorComponents.swift */; };
-		OBJ_840 /* AssetColorContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_235 /* AssetColorContent.swift */; };
-		OBJ_841 /* AssetColorGrayscale.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_236 /* AssetColorGrayscale.swift */; };
-		OBJ_842 /* AssetColorSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_237 /* AssetColorSet.swift */; };
-		OBJ_843 /* AssetColorSetContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_238 /* AssetColorSetContents.swift */; };
-		OBJ_844 /* AssetCustomColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_239 /* AssetCustomColor.swift */; };
-		OBJ_845 /* AssetSystemColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_240 /* AssetSystemColor.swift */; };
-		OBJ_846 /* AssetSystemColorPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_241 /* AssetSystemColorPlatform.swift */; };
-		OBJ_847 /* AssetFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_243 /* AssetFolder.swift */; };
-		OBJ_848 /* AssetFolderContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_244 /* AssetFolderContents.swift */; };
-		OBJ_849 /* AssetFolderProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_245 /* AssetFolderProperties.swift */; };
-		OBJ_850 /* AssetImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_247 /* AssetImage.swift */; };
-		OBJ_851 /* AssetImageAlignmentInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_248 /* AssetImageAlignmentInsets.swift */; };
-		OBJ_852 /* AssetImageAutoScaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_249 /* AssetImageAutoScaling.swift */; };
-		OBJ_853 /* AssetImageGraphicsFeatureSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_250 /* AssetImageGraphicsFeatureSet.swift */; };
-		OBJ_854 /* AssetImageLanguageDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_251 /* AssetImageLanguageDirection.swift */; };
-		OBJ_855 /* AssetImageMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_252 /* AssetImageMemory.swift */; };
-		OBJ_856 /* AssetImageProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_253 /* AssetImageProperties.swift */; };
-		OBJ_857 /* AssetImageScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_254 /* AssetImageScale.swift */; };
-		OBJ_858 /* AssetImageSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_255 /* AssetImageSet.swift */; };
-		OBJ_859 /* AssetImageSetContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_256 /* AssetImageSetContents.swift */; };
-		OBJ_860 /* AssetImageSizeClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_257 /* AssetImageSizeClass.swift */; };
-		OBJ_861 /* AssetImageTemplateRenderingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_258 /* AssetImageTemplateRenderingIntent.swift */; };
-		OBJ_862 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_260 /* Bundle+Extensions.swift */; };
-		OBJ_863 /* CLI+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_261 /* CLI+Extensions.swift */; };
-		OBJ_864 /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_262 /* Collection+Extensions.swift */; };
-		OBJ_865 /* Decodable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_263 /* Decodable+Extensions.swift */; };
-		OBJ_866 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_264 /* DispatchQueue+Extensions.swift */; };
-		OBJ_867 /* Encodable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_265 /* Encodable+Extensions.swift */; };
-		OBJ_868 /* FloatingPoint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_266 /* FloatingPoint+Extensions.swift */; };
-		OBJ_869 /* JSONDecoder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_267 /* JSONDecoder+Extensions.swift */; };
-		OBJ_870 /* JSONEncoder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_268 /* JSONEncoder+Extensions.swift */; };
-		OBJ_871 /* KeyedDecodingContainerProtocol+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_269 /* KeyedDecodingContainerProtocol+Extensions.swift */; };
-		OBJ_872 /* OperatingSystemVersion+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_270 /* OperatingSystemVersion+Extensions.swift */; };
-		OBJ_873 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_271 /* Optional+Extensions.swift */; };
-		OBJ_874 /* Path+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_272 /* Path+Extensions.swift */; };
-		OBJ_875 /* ProcessInfo+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_273 /* ProcessInfo+Extensions.swift */; };
-		OBJ_876 /* Promise+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_274 /* Promise+Extensions.swift */; };
-		OBJ_877 /* RangeReplaceableCollection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_275 /* RangeReplaceableCollection+Extensions.swift */; };
-		OBJ_878 /* Sequence+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_276 /* Sequence+Extensions.swift */; };
-		OBJ_879 /* SingleValueDecodingContainer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_277 /* SingleValueDecodingContainer+Extensions.swift */; };
-		OBJ_880 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_278 /* String+Extensions.swift */; };
-		OBJ_881 /* UnkeyedDecodingContainer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_279 /* UnkeyedDecodingContainer+Extensions.swift */; };
-		OBJ_882 /* HTTPBodyEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_282 /* HTTPBodyEncoder.swift */; };
-		OBJ_883 /* HTTPBodyJSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_283 /* HTTPBodyJSONEncoder.swift */; };
-		OBJ_884 /* HTTPBodyURLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_284 /* HTTPBodyURLEncoder.swift */; };
-		OBJ_885 /* HTTPActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_285 /* HTTPActivityIndicator.swift */; };
-		OBJ_886 /* HTTPAnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_286 /* HTTPAnyEncodable.swift */; };
-		OBJ_887 /* HTTPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_287 /* HTTPError.swift */; };
-		OBJ_888 /* HTTPErrorStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_288 /* HTTPErrorStringConvertible.swift */; };
-		OBJ_889 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_289 /* HTTPHeader.swift */; };
-		OBJ_890 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_290 /* HTTPMethod.swift */; };
-		OBJ_891 /* HTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_291 /* HTTPResponse.swift */; };
-		OBJ_892 /* HTTPRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_292 /* HTTPRoute.swift */; };
-		OBJ_893 /* HTTPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_293 /* HTTPService.swift */; };
-		OBJ_894 /* HTTPServiceTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_294 /* HTTPServiceTask.swift */; };
-		OBJ_895 /* HTTPStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_295 /* HTTPStatusCode.swift */; };
-		OBJ_896 /* HTTPTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_296 /* HTTPTask.swift */; };
-		OBJ_897 /* HTTPUIActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_297 /* HTTPUIActivityIndicator.swift */; };
-		OBJ_898 /* HTTPQueryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_299 /* HTTPQueryEncoder.swift */; };
-		OBJ_899 /* HTTPQueryURLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_300 /* HTTPQueryURLEncoder.swift */; };
-		OBJ_900 /* HTTPDataResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_302 /* HTTPDataResponseSerializer.swift */; };
-		OBJ_901 /* HTTPDecodableResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_303 /* HTTPDecodableResponseSerializer.swift */; };
-		OBJ_902 /* HTTPEmptyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_304 /* HTTPEmptyResponse.swift */; };
-		OBJ_903 /* HTTPJSONResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_305 /* HTTPJSONResponseSerializer.swift */; };
-		OBJ_904 /* HTTPResponseDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_306 /* HTTPResponseDecoder.swift */; };
-		OBJ_905 /* HTTPResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_307 /* HTTPResponseSerializer.swift */; };
-		OBJ_906 /* HTTPStringResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_308 /* HTTPStringResponseSerializer.swift */; };
-		OBJ_907 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_310 /* AnyCodable.swift */; };
-		OBJ_908 /* AnyCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_311 /* AnyCodingKey.swift */; };
-		OBJ_909 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_312 /* Cache.swift */; };
-		OBJ_910 /* MessageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_313 /* MessageError.swift */; };
-		OBJ_911 /* URLArrayEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_315 /* URLArrayEncodingStrategy.swift */; };
-		OBJ_912 /* URLBoolEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_316 /* URLBoolEncodingStrategy.swift */; };
-		OBJ_913 /* URLDateEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_317 /* URLDateEncodingStrategy.swift */; };
-		OBJ_914 /* URLEncodedForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_318 /* URLEncodedForm.swift */; };
-		OBJ_915 /* URLEncodedFormComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_319 /* URLEncodedFormComponent.swift */; };
-		OBJ_916 /* URLEncodedFormContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_320 /* URLEncodedFormContext.swift */; };
-		OBJ_917 /* URLEncodedFormEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_321 /* URLEncodedFormEncoder.swift */; };
-		OBJ_918 /* URLEncodedFormKeyedEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_322 /* URLEncodedFormKeyedEncodingContainer.swift */; };
-		OBJ_919 /* URLEncodedFormSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_323 /* URLEncodedFormSerializer.swift */; };
-		OBJ_920 /* URLEncodedFormSingleValueEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_324 /* URLEncodedFormSingleValueEncodingContainer.swift */; };
-		OBJ_921 /* URLEncodedFormUnkeyedEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_325 /* URLEncodedFormUnkeyedEncodingContainer.swift */; };
-		OBJ_922 /* URLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_326 /* URLEncoder.swift */; };
-		OBJ_923 /* URLSpaceEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_327 /* URLSpaceEncodingStrategy.swift */; };
-		OBJ_925 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PromiseKit::PromiseKit::Product" /* PromiseKit.framework */; };
-		OBJ_926 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PathKit::PathKit::Product" /* PathKit.framework */; };
-		OBJ_927 /* SwiftCLI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftCLI::SwiftCLI::Product" /* SwiftCLI.framework */; };
-		OBJ_935 /* FugenToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_335 /* FugenToolsTests.swift */; };
-		OBJ_936 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_336 /* XCTestManifests.swift */; };
-		OBJ_938 /* FugenTools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Fugen::FugenTools::Product" /* FugenTools.framework */; };
-		OBJ_939 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PromiseKit::PromiseKit::Product" /* PromiseKit.framework */; };
-		OBJ_940 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PathKit::PathKit::Product" /* PathKit.framework */; };
-		OBJ_941 /* SwiftCLI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftCLI::SwiftCLI::Product" /* SwiftCLI.framework */; };
-		OBJ_950 /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_426 /* PathKit.swift */; };
-		OBJ_957 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_425 /* Package.swift */; };
-		OBJ_962 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_373 /* Box.swift */; };
-		OBJ_963 /* Catchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_374 /* Catchable.swift */; };
-		OBJ_964 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_375 /* Configuration.swift */; };
-		OBJ_965 /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_376 /* CustomStringConvertible.swift */; };
-		OBJ_966 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_377 /* Error.swift */; };
-		OBJ_967 /* Guarantee.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_378 /* Guarantee.swift */; };
-		OBJ_968 /* LogEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_379 /* LogEvent.swift */; };
-		OBJ_969 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_380 /* Promise.swift */; };
-		OBJ_970 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_381 /* Resolver.swift */; };
-		OBJ_971 /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_382 /* Thenable.swift */; };
-		OBJ_972 /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_383 /* after.swift */; };
-		OBJ_973 /* firstly.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_384 /* firstly.swift */; };
-		OBJ_974 /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_385 /* hang.swift */; };
-		OBJ_975 /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_386 /* race.swift */; };
-		OBJ_976 /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_387 /* when.swift */; };
-		OBJ_983 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_372 /* Package.swift */; };
-		OBJ_988 /* BackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_459 /* BackgroundColor.swift */; };
-		OBJ_989 /* CodesParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_460 /* CodesParser.swift */; };
-		OBJ_990 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_461 /* Color.swift */; };
-		OBJ_991 /* ControlCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_462 /* ControlCode.swift */; };
-		OBJ_992 /* ModesExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_463 /* ModesExtractor.swift */; };
-		OBJ_993 /* OutputTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_464 /* OutputTarget.swift */; };
-		OBJ_994 /* Rainbow.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_465 /* Rainbow.swift */; };
-		OBJ_995 /* String+Rainbow.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_466 /* String+Rainbow.swift */; };
-		OBJ_996 /* StringGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_467 /* StringGenerator.swift */; };
-		OBJ_997 /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_468 /* Style.swift */; };
-		OBJ_998 /* XcodeColorsSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_469 /* XcodeColorsSupport.swift */; };
+		8E53204025330481006AA460 /* StencilModificator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E53203E25330481006AA460 /* StencilModificator.swift */; };
+		8E53204125330481006AA460 /* StencilModificatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E53203F25330481006AA460 /* StencilModificatorError.swift */; };
+		8E53205C25330490006AA460 /* StencilFontModificator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E53205A25330490006AA460 /* StencilFontModificator.swift */; };
+		8E53205D25330490006AA460 /* StencilFontInitializerModificator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E53205B25330490006AA460 /* StencilFontInitializerModificator.swift */; };
+		8E5320A725335F8A006AA460 /* StencilFontSystemFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E5320A625335F8A006AA460 /* StencilFontSystemFilter.swift */; };
+		OBJ_1000 /* ControlCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_467 /* ControlCode.swift */; };
+		OBJ_1001 /* ModesExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_468 /* ModesExtractor.swift */; };
+		OBJ_1002 /* OutputTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_469 /* OutputTarget.swift */; };
+		OBJ_1003 /* Rainbow.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_470 /* Rainbow.swift */; };
+		OBJ_1004 /* String+Rainbow.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_471 /* String+Rainbow.swift */; };
+		OBJ_1005 /* StringGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_472 /* StringGenerator.swift */; };
+		OBJ_1006 /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_473 /* Style.swift */; };
+		OBJ_1007 /* XcodeColorsSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_474 /* XcodeColorsSupport.swift */; };
+		OBJ_1014 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_463 /* Package.swift */; };
+		OBJ_1019 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_409 /* Context.swift */; };
+		OBJ_1020 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_410 /* Environment.swift */; };
+		OBJ_1021 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_411 /* Errors.swift */; };
+		OBJ_1022 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_412 /* Expression.swift */; };
+		OBJ_1023 /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_413 /* Extension.swift */; };
+		OBJ_1024 /* FilterTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_414 /* FilterTag.swift */; };
+		OBJ_1025 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_415 /* Filters.swift */; };
+		OBJ_1026 /* ForTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_416 /* ForTag.swift */; };
+		OBJ_1027 /* IfTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_417 /* IfTag.swift */; };
+		OBJ_1028 /* Include.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_418 /* Include.swift */; };
+		OBJ_1029 /* Inheritence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_419 /* Inheritence.swift */; };
+		OBJ_1030 /* KeyPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_420 /* KeyPath.swift */; };
+		OBJ_1031 /* Lexer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_421 /* Lexer.swift */; };
+		OBJ_1032 /* Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_422 /* Loader.swift */; };
+		OBJ_1033 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_423 /* Node.swift */; };
+		OBJ_1034 /* NowTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_424 /* NowTag.swift */; };
+		OBJ_1035 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_425 /* Parser.swift */; };
+		OBJ_1036 /* Template.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_426 /* Template.swift */; };
+		OBJ_1037 /* Tokenizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_427 /* Tokenizer.swift */; };
+		OBJ_1038 /* Variable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_428 /* Variable.swift */; };
+		OBJ_1040 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PathKit::PathKit::Product" /* PathKit.framework */; };
+		OBJ_1047 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_408 /* Package.swift */; };
+		OBJ_1052 /* CallMacroNodes.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_395 /* CallMacroNodes.swift */; };
+		OBJ_1053 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_396 /* Context.swift */; };
+		OBJ_1054 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_397 /* Environment.swift */; };
+		OBJ_1055 /* Filters+Numbers.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_398 /* Filters+Numbers.swift */; };
+		OBJ_1056 /* Filters+Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_399 /* Filters+Strings.swift */; };
+		OBJ_1057 /* Filters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_400 /* Filters.swift */; };
+		OBJ_1058 /* MapNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_401 /* MapNode.swift */; };
+		OBJ_1059 /* Parameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_402 /* Parameters.swift */; };
+		OBJ_1060 /* SetNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_403 /* SetNode.swift */; };
+		OBJ_1061 /* StencilSwiftTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_404 /* StencilSwiftTemplate.swift */; };
+		OBJ_1062 /* SwiftIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_405 /* SwiftIdentifier.swift */; };
+		OBJ_1064 /* Stencil.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Stencil::Stencil::Product" /* Stencil.framework */; };
+		OBJ_1065 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PathKit::PathKit::Product" /* PathKit.framework */; };
+		OBJ_1073 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_406 /* Package.swift */; };
+		OBJ_1078 /* ArgumentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_477 /* ArgumentList.swift */; };
+		OBJ_1079 /* ArgumentListManipulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_478 /* ArgumentListManipulator.swift */; };
+		OBJ_1080 /* CLI.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_479 /* CLI.swift */; };
+		OBJ_1081 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_480 /* Command.swift */; };
+		OBJ_1082 /* Compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_481 /* Compatibility.swift */; };
+		OBJ_1083 /* CompletionGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_482 /* CompletionGenerator.swift */; };
+		OBJ_1084 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_483 /* Error.swift */; };
+		OBJ_1085 /* HelpCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_484 /* HelpCommand.swift */; };
+		OBJ_1086 /* HelpMessageGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_485 /* HelpMessageGenerator.swift */; };
+		OBJ_1087 /* Input.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_486 /* Input.swift */; };
+		OBJ_1088 /* Option.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_487 /* Option.swift */; };
+		OBJ_1089 /* OptionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_488 /* OptionGroup.swift */; };
+		OBJ_1090 /* OptionRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_489 /* OptionRegistry.swift */; };
+		OBJ_1091 /* Parameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_490 /* Parameter.swift */; };
+		OBJ_1092 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_491 /* Parser.swift */; };
+		OBJ_1093 /* Path.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_492 /* Path.swift */; };
+		OBJ_1094 /* Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_493 /* Stream.swift */; };
+		OBJ_1095 /* Task.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_494 /* Task.swift */; };
+		OBJ_1096 /* Term.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_495 /* Term.swift */; };
+		OBJ_1097 /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_496 /* Validation.swift */; };
+		OBJ_1098 /* ValueBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_497 /* ValueBox.swift */; };
+		OBJ_1099 /* VersionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_498 /* VersionCommand.swift */; };
+		OBJ_1106 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_499 /* Package.swift */; };
+		OBJ_1111 /* Constructor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_445 /* Constructor.swift */; };
+		OBJ_1112 /* Decoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_446 /* Decoder.swift */; };
+		OBJ_1113 /* Emitter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_447 /* Emitter.swift */; };
+		OBJ_1114 /* Encoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_448 /* Encoder.swift */; };
+		OBJ_1115 /* Mark.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_449 /* Mark.swift */; };
+		OBJ_1116 /* Node.Mapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_450 /* Node.Mapping.swift */; };
+		OBJ_1117 /* Node.Scalar.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_451 /* Node.Scalar.swift */; };
+		OBJ_1118 /* Node.Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_452 /* Node.Sequence.swift */; };
+		OBJ_1119 /* Node.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_453 /* Node.swift */; };
+		OBJ_1120 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_454 /* Parser.swift */; };
+		OBJ_1121 /* Representer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_455 /* Representer.swift */; };
+		OBJ_1122 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_456 /* Resolver.swift */; };
+		OBJ_1123 /* String+Yams.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_457 /* String+Yams.swift */; };
+		OBJ_1124 /* Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_458 /* Tag.swift */; };
+		OBJ_1125 /* YamlError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_459 /* YamlError.swift */; };
+		OBJ_1126 /* shim.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_460 /* shim.swift */; };
+		OBJ_1128 /* CYaml.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::CYaml::Product" /* CYaml.framework */; };
+		OBJ_1135 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_461 /* Package.swift */; };
+		OBJ_532 /* api.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_435 /* api.c */; };
+		OBJ_533 /* emitter.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_436 /* emitter.c */; };
+		OBJ_534 /* parser.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_437 /* parser.c */; };
+		OBJ_535 /* reader.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_438 /* reader.c */; };
+		OBJ_536 /* scanner.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_439 /* scanner.c */; };
+		OBJ_537 /* writer.c in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_440 /* writer.c */; };
+		OBJ_539 /* CYaml.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_442 /* CYaml.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_540 /* yaml.h in Headers */ = {isa = PBXBuildFile; fileRef = OBJ_443 /* yaml.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		OBJ_547 /* DictionaryComponentDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_346 /* DictionaryComponentDecoder.swift */; };
+		OBJ_548 /* DictionaryDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_347 /* DictionaryDecoder.swift */; };
+		OBJ_549 /* DictionaryDecodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_348 /* DictionaryDecodingOptions.swift */; };
+		OBJ_550 /* DictionaryKeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_349 /* DictionaryKeyedDecodingContainer.swift */; };
+		OBJ_551 /* DictionarySingleValueDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_350 /* DictionarySingleValueDecodingContainer.swift */; };
+		OBJ_552 /* DictionaryUnkeyedDecodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_351 /* DictionaryUnkeyedDecodingContainer.swift */; };
+		OBJ_553 /* DictionaryDataDecodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_353 /* DictionaryDataDecodingStrategy.swift */; };
+		OBJ_554 /* DictionaryDateDecodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_354 /* DictionaryDateDecodingStrategy.swift */; };
+		OBJ_555 /* DictionaryKeyDecodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_355 /* DictionaryKeyDecodingStrategy.swift */; };
+		OBJ_556 /* DictionaryNonConformingFloatDecodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_356 /* DictionaryNonConformingFloatDecodingStrategy.swift */; };
+		OBJ_557 /* DictionaryAnyKeyedEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_358 /* DictionaryAnyKeyedEncodingContainer.swift */; };
+		OBJ_558 /* DictionaryComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_359 /* DictionaryComponent.swift */; };
+		OBJ_559 /* DictionaryComponentContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_360 /* DictionaryComponentContainer.swift */; };
+		OBJ_560 /* DictionaryComponentEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_361 /* DictionaryComponentEncoder.swift */; };
+		OBJ_561 /* DictionaryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_362 /* DictionaryEncoder.swift */; };
+		OBJ_562 /* DictionaryEncodingOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_363 /* DictionaryEncodingOptions.swift */; };
+		OBJ_563 /* DictionaryKeyedEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_364 /* DictionaryKeyedEncodingContainer.swift */; };
+		OBJ_564 /* DictionarySingleValueEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_365 /* DictionarySingleValueEncodingContainer.swift */; };
+		OBJ_565 /* DictionaryUnkeyedEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_366 /* DictionaryUnkeyedEncodingContainer.swift */; };
+		OBJ_566 /* DictionaryDataEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_368 /* DictionaryDataEncodingStrategy.swift */; };
+		OBJ_567 /* DictionaryDateEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_369 /* DictionaryDateEncodingStrategy.swift */; };
+		OBJ_568 /* DictionaryKeyEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_370 /* DictionaryKeyEncodingStrategy.swift */; };
+		OBJ_569 /* DictionaryNonConformingFloatEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_371 /* DictionaryNonConformingFloatEncodingStrategy.swift */; };
+		OBJ_570 /* AnyCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_373 /* AnyCodingKey.swift */; };
+		OBJ_571 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_374 /* Optional+Extensions.swift */; };
+		OBJ_572 /* RangeReplaceableCollection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_375 /* RangeReplaceableCollection+Extensions.swift */; };
+		OBJ_579 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_344 /* Package.swift */; };
+		OBJ_585 /* AsyncExecutableCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* AsyncExecutableCommand.swift */; };
+		OBJ_586 /* ColorStylesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_11 /* ColorStylesCommand.swift */; };
+		OBJ_587 /* GenerateCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* GenerateCommand.swift */; };
+		OBJ_588 /* GenerationConfigurableCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* GenerationConfigurableCommand.swift */; };
+		OBJ_589 /* ImagesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* ImagesCommand.swift */; };
+		OBJ_590 /* ShadowStylesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* ShadowStylesCommand.swift */; };
+		OBJ_591 /* TextStylesCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_16 /* TextStylesCommand.swift */; };
+		OBJ_592 /* Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_17 /* Dependencies.swift */; };
+		OBJ_593 /* ColorStylesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_20 /* ColorStylesContext.swift */; };
+		OBJ_594 /* ColorStylesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_21 /* ColorStylesGenerator.swift */; };
+		OBJ_595 /* DefaultColorStylesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_22 /* DefaultColorStylesGenerator.swift */; };
+		OBJ_596 /* GenerationParametersError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_23 /* GenerationParametersError.swift */; };
+		OBJ_597 /* GenerationParametersResolving.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_24 /* GenerationParametersResolving.swift */; };
+		OBJ_598 /* DefaultImagesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_26 /* DefaultImagesGenerator.swift */; };
+		OBJ_599 /* ImagesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_27 /* ImagesContext.swift */; };
+		OBJ_600 /* ImagesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_28 /* ImagesGenerator.swift */; };
+		OBJ_601 /* DefaultLibraryGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_30 /* DefaultLibraryGenerator.swift */; };
+		OBJ_602 /* LibraryGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_31 /* LibraryGenerator.swift */; };
+		OBJ_603 /* DefaultShadowStylesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_33 /* DefaultShadowStylesGenerator.swift */; };
+		OBJ_604 /* ShadowStylesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_34 /* ShadowStylesContext.swift */; };
+		OBJ_605 /* ShadowStylesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_35 /* ShadowStylesGenerator.swift */; };
+		OBJ_606 /* DefaultTextStylesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_37 /* DefaultTextStylesGenerator.swift */; };
+		OBJ_607 /* TextStylesContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_38 /* TextStylesContext.swift */; };
+		OBJ_608 /* TextStylesGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_39 /* TextStylesGenerator.swift */; };
+		OBJ_609 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_41 /* Color.swift */; };
+		OBJ_610 /* ColorStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_43 /* ColorStyle.swift */; };
+		OBJ_611 /* ColorStyleAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_44 /* ColorStyleAsset.swift */; };
+		OBJ_612 /* ColorStyleNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_45 /* ColorStyleNode.swift */; };
+		OBJ_613 /* AccessTokenConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_47 /* AccessTokenConfiguration.swift */; };
+		OBJ_614 /* BaseConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_48 /* BaseConfiguration.swift */; };
+		OBJ_615 /* ColorStylesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_49 /* ColorStylesConfiguration.swift */; };
+		OBJ_616 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_50 /* Configuration.swift */; };
+		OBJ_617 /* FileConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_51 /* FileConfiguration.swift */; };
+		OBJ_618 /* GenerationConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_52 /* GenerationConfiguration.swift */; };
+		OBJ_619 /* ImagesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_53 /* ImagesConfiguration.swift */; };
+		OBJ_620 /* ShadowStylesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_54 /* ShadowStylesConfiguration.swift */; };
+		OBJ_621 /* TextStylesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_55 /* TextStylesConfiguration.swift */; };
+		OBJ_622 /* Font.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_56 /* Font.swift */; };
+		OBJ_623 /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_58 /* Image.swift */; };
+		OBJ_624 /* ImageAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_59 /* ImageAsset.swift */; };
+		OBJ_625 /* ImageFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_60 /* ImageFormat.swift */; };
+		OBJ_626 /* ImageNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_61 /* ImageNode.swift */; };
+		OBJ_627 /* ImageRenderedNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_62 /* ImageRenderedNode.swift */; };
+		OBJ_628 /* ImageResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_63 /* ImageResource.swift */; };
+		OBJ_629 /* ImageScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_64 /* ImageScale.swift */; };
+		OBJ_630 /* FileParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_66 /* FileParameters.swift */; };
+		OBJ_631 /* GenerationParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_67 /* GenerationParameters.swift */; };
+		OBJ_632 /* ImagesParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_68 /* ImagesParameters.swift */; };
+		OBJ_633 /* NodesParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_69 /* NodesParameters.swift */; };
+		OBJ_634 /* RenderParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_70 /* RenderParameters.swift */; };
+		OBJ_635 /* Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_72 /* Shadow.swift */; };
+		OBJ_636 /* ShadowStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_73 /* ShadowStyle.swift */; };
+		OBJ_637 /* ShadowStyleNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_74 /* ShadowStyleNode.swift */; };
+		OBJ_638 /* ShadowType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_75 /* ShadowType.swift */; };
+		OBJ_639 /* TextStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_77 /* TextStyle.swift */; };
+		OBJ_640 /* TextStyleColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_78 /* TextStyleColor.swift */; };
+		OBJ_641 /* TextStyleNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_79 /* TextStyleNode.swift */; };
+		OBJ_642 /* Vector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_80 /* Vector.swift */; };
+		OBJ_643 /* AssetsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_83 /* AssetsProvider.swift */; };
+		OBJ_644 /* DefaultAssetsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_84 /* DefaultAssetsProvider.swift */; };
+		OBJ_645 /* ColorStyleAssetsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_87 /* ColorStyleAssetsProvider.swift */; };
+		OBJ_646 /* DefaultColorStyleAssetsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_88 /* DefaultColorStyleAssetsProvider.swift */; };
+		OBJ_647 /* ColorStylesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_89 /* ColorStylesProvider.swift */; };
+		OBJ_648 /* ColorStylesProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_90 /* ColorStylesProviderError.swift */; };
+		OBJ_649 /* DefaultColorStylesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_91 /* DefaultColorStylesProvider.swift */; };
+		OBJ_650 /* ConfigurationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_93 /* ConfigurationProvider.swift */; };
+		OBJ_651 /* DefaultConfigurationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_94 /* DefaultConfigurationProvider.swift */; };
+		OBJ_652 /* DataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_96 /* DataProvider.swift */; };
+		OBJ_653 /* DefaultDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_97 /* DefaultDataProvider.swift */; };
+		OBJ_654 /* FigmaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_100 /* FigmaError.swift */; };
+		OBJ_655 /* FigmaImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_101 /* FigmaImages.swift */; };
+		OBJ_656 /* FigmaBlendMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_103 /* FigmaBlendMode.swift */; };
+		OBJ_657 /* FigmaBooleanOperationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_104 /* FigmaBooleanOperationType.swift */; };
+		OBJ_658 /* FigmaColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_105 /* FigmaColor.swift */; };
+		OBJ_659 /* FigmaColorStop.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_106 /* FigmaColorStop.swift */; };
+		OBJ_660 /* FigmaComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_107 /* FigmaComponent.swift */; };
+		OBJ_661 /* FigmaConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_108 /* FigmaConstraint.swift */; };
+		OBJ_662 /* FigmaConstraintType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_109 /* FigmaConstraintType.swift */; };
+		OBJ_663 /* FigmaEasingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_110 /* FigmaEasingType.swift */; };
+		OBJ_664 /* FigmaEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_111 /* FigmaEffect.swift */; };
+		OBJ_665 /* FigmaEffectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_112 /* FigmaEffectType.swift */; };
+		OBJ_666 /* FigmaExportSetting.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_113 /* FigmaExportSetting.swift */; };
+		OBJ_667 /* FigmaFrameOffset.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_114 /* FigmaFrameOffset.swift */; };
+		OBJ_668 /* FigmaImageFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_115 /* FigmaImageFormat.swift */; };
+		OBJ_669 /* FigmaLayoutConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_116 /* FigmaLayoutConstraint.swift */; };
+		OBJ_670 /* FigmaLayoutGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_117 /* FigmaLayoutGrid.swift */; };
+		OBJ_671 /* FigmaLayoutGridAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_118 /* FigmaLayoutGridAlignment.swift */; };
+		OBJ_672 /* FigmaLayoutGridPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_119 /* FigmaLayoutGridPattern.swift */; };
+		OBJ_673 /* FigmaLayoutHorizontalConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_120 /* FigmaLayoutHorizontalConstraint.swift */; };
+		OBJ_674 /* FigmaLayoutVerticalConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_121 /* FigmaLayoutVerticalConstraint.swift */; };
+		OBJ_675 /* FigmaLineHeightUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_122 /* FigmaLineHeightUnit.swift */; };
+		OBJ_676 /* FigmaPaint.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_123 /* FigmaPaint.swift */; };
+		OBJ_677 /* FigmaPaintType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_124 /* FigmaPaintType.swift */; };
+		OBJ_678 /* FigmaRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_125 /* FigmaRectangle.swift */; };
+		OBJ_679 /* FigmaScaleMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_126 /* FigmaScaleMode.swift */; };
+		OBJ_680 /* FigmaStrokeAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_127 /* FigmaStrokeAlignment.swift */; };
+		OBJ_681 /* FigmaStrokeCap.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_128 /* FigmaStrokeCap.swift */; };
+		OBJ_682 /* FigmaStrokeJoin.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_129 /* FigmaStrokeJoin.swift */; };
+		OBJ_683 /* FigmaStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_130 /* FigmaStyle.swift */; };
+		OBJ_684 /* FigmaStyleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_131 /* FigmaStyleType.swift */; };
+		OBJ_685 /* FigmaTextCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_132 /* FigmaTextCase.swift */; };
+		OBJ_686 /* FigmaTextDecoration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_133 /* FigmaTextDecoration.swift */; };
+		OBJ_687 /* FigmaTextHorizontalAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_134 /* FigmaTextHorizontalAlignment.swift */; };
+		OBJ_688 /* FigmaTextVerticalAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_135 /* FigmaTextVerticalAlignment.swift */; };
+		OBJ_689 /* FigmaTypeStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_136 /* FigmaTypeStyle.swift */; };
+		OBJ_690 /* FigmaVector.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_137 /* FigmaVector.swift */; };
+		OBJ_691 /* FigmaBooleanOperationNodePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_139 /* FigmaBooleanOperationNodePayload.swift */; };
+		OBJ_692 /* FigmaCanvasNodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_140 /* FigmaCanvasNodeInfo.swift */; };
+		OBJ_693 /* FigmaDocumentNodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_141 /* FigmaDocumentNodeInfo.swift */; };
+		OBJ_694 /* FigmaFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_142 /* FigmaFile.swift */; };
+		OBJ_695 /* FigmaFrameNodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_143 /* FigmaFrameNodeInfo.swift */; };
+		OBJ_696 /* FigmaInstanceNodePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_144 /* FigmaInstanceNodePayload.swift */; };
+		OBJ_697 /* FigmaNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_145 /* FigmaNode.swift */; };
+		OBJ_698 /* FigmaNodeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_146 /* FigmaNodeType.swift */; };
+		OBJ_699 /* FigmaRectangleNodePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_147 /* FigmaRectangleNodePayload.swift */; };
+		OBJ_700 /* FigmaSliceNodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_148 /* FigmaSliceNodeInfo.swift */; };
+		OBJ_701 /* FigmaTextNodePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_149 /* FigmaTextNodePayload.swift */; };
+		OBJ_702 /* FigmaVectorNodeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_150 /* FigmaVectorNodeInfo.swift */; };
+		OBJ_703 /* DefaultFigmaAPIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_151 /* DefaultFigmaAPIProvider.swift */; };
+		OBJ_704 /* FigmaAPIEmptyParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_152 /* FigmaAPIEmptyParameters.swift */; };
+		OBJ_705 /* FigmaAPIEmptyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_153 /* FigmaAPIEmptyResponse.swift */; };
+		OBJ_706 /* FigmaAPIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_154 /* FigmaAPIProvider.swift */; };
+		OBJ_707 /* FigmaAPIRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_155 /* FigmaAPIRoute.swift */; };
+		OBJ_708 /* FigmaAPIVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_156 /* FigmaAPIVersion.swift */; };
+		OBJ_709 /* FigmaHTTPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_157 /* FigmaHTTPService.swift */; };
+		OBJ_710 /* FigmaAPIFileRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_159 /* FigmaAPIFileRoute.swift */; };
+		OBJ_711 /* FigmaAPIFileRouteQueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_160 /* FigmaAPIFileRouteQueryParameters.swift */; };
+		OBJ_712 /* FigmaAPIImagesRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_161 /* FigmaAPIImagesRoute.swift */; };
+		OBJ_713 /* FigmaAPIImagesRouteQueryParameters.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_162 /* FigmaAPIImagesRouteQueryParameters.swift */; };
+		OBJ_714 /* DefaultFigmaFilesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_164 /* DefaultFigmaFilesProvider.swift */; };
+		OBJ_715 /* FigmaFilesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_165 /* FigmaFilesProvider.swift */; };
+		OBJ_716 /* DefaultFigmaNodesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_167 /* DefaultFigmaNodesProvider.swift */; };
+		OBJ_717 /* FigmaNodesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_168 /* FigmaNodesProvider.swift */; };
+		OBJ_718 /* FigmaNodesProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_169 /* FigmaNodesProviderError.swift */; };
+		OBJ_719 /* DefaultImageAssetsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_172 /* DefaultImageAssetsProvider.swift */; };
+		OBJ_720 /* ImageAssetsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_173 /* ImageAssetsProvider.swift */; };
+		OBJ_721 /* DefaultImagesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_174 /* DefaultImagesProvider.swift */; };
+		OBJ_722 /* ImagesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_175 /* ImagesProvider.swift */; };
+		OBJ_723 /* ImagesProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_176 /* ImagesProviderError.swift */; };
+		OBJ_724 /* DefaultImageRenderProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_178 /* DefaultImageRenderProvider.swift */; };
+		OBJ_725 /* ImageRenderProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_179 /* ImageRenderProvider.swift */; };
+		OBJ_726 /* ImageRenderProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_180 /* ImageRenderProviderError.swift */; };
+		OBJ_727 /* DefaultImageResourcesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_182 /* DefaultImageResourcesProvider.swift */; };
+		OBJ_728 /* ImageResourcesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_183 /* ImageResourcesProvider.swift */; };
+		OBJ_729 /* DefaultShadowStylesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_185 /* DefaultShadowStylesProvider.swift */; };
+		OBJ_730 /* ShadowStylesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_186 /* ShadowStylesProvider.swift */; };
+		OBJ_731 /* ShadowStylesProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_187 /* ShadowStylesProviderError.swift */; };
+		OBJ_732 /* DefaultTextStylesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_189 /* DefaultTextStylesProvider.swift */; };
+		OBJ_733 /* TextStylesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_190 /* TextStylesProvider.swift */; };
+		OBJ_734 /* TextStylesProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_191 /* TextStylesProviderError.swift */; };
+		OBJ_735 /* DefaultTemplateContextCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_193 /* DefaultTemplateContextCoder.swift */; };
+		OBJ_736 /* DefaultTemplateRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_194 /* DefaultTemplateRenderer.swift */; };
+		OBJ_737 /* RenderDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_195 /* RenderDestination.swift */; };
+		OBJ_738 /* RenderTemplate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_196 /* RenderTemplate.swift */; };
+		OBJ_739 /* RenderTemplateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_197 /* RenderTemplateType.swift */; };
+		OBJ_740 /* StencilColorFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_200 /* StencilColorFilter.swift */; };
+		OBJ_741 /* StencilColorInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_201 /* StencilColorInfoFilter.swift */; };
+		OBJ_742 /* StencilColorRGBAHexInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_202 /* StencilColorRGBAHexInfoFilter.swift */; };
+		OBJ_743 /* StencilColorRGBAInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_203 /* StencilColorRGBAInfoFilter.swift */; };
+		OBJ_744 /* StencilColorRGBHexInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_204 /* StencilColorRGBHexInfoFilter.swift */; };
+		OBJ_745 /* StencilColorRGBInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_205 /* StencilColorRGBInfoFilter.swift */; };
+		OBJ_746 /* StencilFontFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_207 /* StencilFontFilter.swift */; };
+		OBJ_747 /* StencilFontInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_208 /* StencilFontInfoFilter.swift */; };
+		OBJ_748 /* StencilByteToFloatFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_210 /* StencilByteToFloatFilter.swift */; };
+		OBJ_749 /* StencilByteToHexFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_211 /* StencilByteToHexFilter.swift */; };
+		OBJ_750 /* StencilFloatToByteFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_212 /* StencilFloatToByteFilter.swift */; };
+		OBJ_751 /* StencilHexToByteFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_213 /* StencilHexToByteFilter.swift */; };
+		OBJ_752 /* StencilExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_214 /* StencilExtension.swift */; };
+		OBJ_753 /* StencilFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_215 /* StencilFilter.swift */; };
+		OBJ_754 /* StencilFilterError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_216 /* StencilFilterError.swift */; };
+		OBJ_755 /* StencilTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_217 /* StencilTag.swift */; };
+		OBJ_756 /* StencilTagError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_218 /* StencilTagError.swift */; };
+		OBJ_757 /* StencilTagNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_219 /* StencilTagNode.swift */; };
+		OBJ_758 /* StencilVectorFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_221 /* StencilVectorFilter.swift */; };
+		OBJ_759 /* StencilVectorInfoFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_222 /* StencilVectorInfoFilter.swift */; };
+		OBJ_760 /* TemplateContextCoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_223 /* TemplateContextCoder.swift */; };
+		OBJ_761 /* TemplateRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_224 /* TemplateRenderer.swift */; };
+		OBJ_762 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_225 /* main.swift */; };
+		OBJ_764 /* DictionaryCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "DictionaryCoder::DictionaryCoder::Product" /* DictionaryCoder.framework */; };
+		OBJ_765 /* StencilSwiftKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "StencilSwiftKit::StencilSwiftKit::Product" /* StencilSwiftKit.framework */; };
+		OBJ_766 /* Stencil.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Stencil::Stencil::Product" /* Stencil.framework */; };
+		OBJ_767 /* Rainbow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Rainbow::Rainbow::Product" /* Rainbow.framework */; };
+		OBJ_768 /* Yams.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::Yams::Product" /* Yams.framework */; };
+		OBJ_769 /* CYaml.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::CYaml::Product" /* CYaml.framework */; };
+		OBJ_770 /* FugenTools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Fugen::FugenTools::Product" /* FugenTools.framework */; };
+		OBJ_771 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PromiseKit::PromiseKit::Product" /* PromiseKit.framework */; };
+		OBJ_772 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PathKit::PathKit::Product" /* PathKit.framework */; };
+		OBJ_773 /* SwiftCLI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftCLI::SwiftCLI::Product" /* SwiftCLI.framework */; };
+		OBJ_797 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
+		OBJ_810 /* FugenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_336 /* FugenTests.swift */; };
+		OBJ_811 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_337 /* XCTestManifests.swift */; };
+		OBJ_813 /* DictionaryCoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "DictionaryCoder::DictionaryCoder::Product" /* DictionaryCoder.framework */; };
+		OBJ_814 /* StencilSwiftKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "StencilSwiftKit::StencilSwiftKit::Product" /* StencilSwiftKit.framework */; };
+		OBJ_815 /* Stencil.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Stencil::Stencil::Product" /* Stencil.framework */; };
+		OBJ_816 /* Rainbow.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Rainbow::Rainbow::Product" /* Rainbow.framework */; };
+		OBJ_817 /* Yams.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::Yams::Product" /* Yams.framework */; };
+		OBJ_818 /* CYaml.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Yams::CYaml::Product" /* CYaml.framework */; };
+		OBJ_819 /* FugenTools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Fugen::FugenTools::Product" /* FugenTools.framework */; };
+		OBJ_820 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PromiseKit::PromiseKit::Product" /* PromiseKit.framework */; };
+		OBJ_821 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PathKit::PathKit::Product" /* PathKit.framework */; };
+		OBJ_822 /* SwiftCLI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftCLI::SwiftCLI::Product" /* SwiftCLI.framework */; };
+		OBJ_838 /* AssetAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_228 /* AssetAppearance.swift */; };
+		OBJ_839 /* AssetAppearanceContrast.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_229 /* AssetAppearanceContrast.swift */; };
+		OBJ_840 /* AssetAppearanceLuminosity.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_230 /* AssetAppearanceLuminosity.swift */; };
+		OBJ_841 /* AssetCompressionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_231 /* AssetCompressionType.swift */; };
+		OBJ_842 /* AssetDisplayGamut.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_232 /* AssetDisplayGamut.swift */; };
+		OBJ_843 /* AssetIdiom.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_233 /* AssetIdiom.swift */; };
+		OBJ_844 /* AssetIdiomIPadSubtype.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_234 /* AssetIdiomIPadSubtype.swift */; };
+		OBJ_845 /* AssetInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_235 /* AssetInfo.swift */; };
+		OBJ_846 /* AssetNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_236 /* AssetNode.swift */; };
+		OBJ_847 /* AssetColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_238 /* AssetColor.swift */; };
+		OBJ_848 /* AssetColorComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_239 /* AssetColorComponents.swift */; };
+		OBJ_849 /* AssetColorContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_240 /* AssetColorContent.swift */; };
+		OBJ_850 /* AssetColorGrayscale.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_241 /* AssetColorGrayscale.swift */; };
+		OBJ_851 /* AssetColorSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_242 /* AssetColorSet.swift */; };
+		OBJ_852 /* AssetColorSetContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_243 /* AssetColorSetContents.swift */; };
+		OBJ_853 /* AssetCustomColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_244 /* AssetCustomColor.swift */; };
+		OBJ_854 /* AssetSystemColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_245 /* AssetSystemColor.swift */; };
+		OBJ_855 /* AssetSystemColorPlatform.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_246 /* AssetSystemColorPlatform.swift */; };
+		OBJ_856 /* AssetFolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_248 /* AssetFolder.swift */; };
+		OBJ_857 /* AssetFolderContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_249 /* AssetFolderContents.swift */; };
+		OBJ_858 /* AssetFolderProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_250 /* AssetFolderProperties.swift */; };
+		OBJ_859 /* AssetImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_252 /* AssetImage.swift */; };
+		OBJ_860 /* AssetImageAlignmentInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_253 /* AssetImageAlignmentInsets.swift */; };
+		OBJ_861 /* AssetImageAutoScaling.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_254 /* AssetImageAutoScaling.swift */; };
+		OBJ_862 /* AssetImageGraphicsFeatureSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_255 /* AssetImageGraphicsFeatureSet.swift */; };
+		OBJ_863 /* AssetImageLanguageDirection.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_256 /* AssetImageLanguageDirection.swift */; };
+		OBJ_864 /* AssetImageMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_257 /* AssetImageMemory.swift */; };
+		OBJ_865 /* AssetImageProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_258 /* AssetImageProperties.swift */; };
+		OBJ_866 /* AssetImageScale.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_259 /* AssetImageScale.swift */; };
+		OBJ_867 /* AssetImageSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_260 /* AssetImageSet.swift */; };
+		OBJ_868 /* AssetImageSetContents.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_261 /* AssetImageSetContents.swift */; };
+		OBJ_869 /* AssetImageSizeClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_262 /* AssetImageSizeClass.swift */; };
+		OBJ_870 /* AssetImageTemplateRenderingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_263 /* AssetImageTemplateRenderingIntent.swift */; };
+		OBJ_871 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_265 /* Bundle+Extensions.swift */; };
+		OBJ_872 /* CLI+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_266 /* CLI+Extensions.swift */; };
+		OBJ_873 /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_267 /* Collection+Extensions.swift */; };
+		OBJ_874 /* Decodable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_268 /* Decodable+Extensions.swift */; };
+		OBJ_875 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_269 /* DispatchQueue+Extensions.swift */; };
+		OBJ_876 /* Encodable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_270 /* Encodable+Extensions.swift */; };
+		OBJ_877 /* FloatingPoint+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_271 /* FloatingPoint+Extensions.swift */; };
+		OBJ_878 /* JSONDecoder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_272 /* JSONDecoder+Extensions.swift */; };
+		OBJ_879 /* JSONEncoder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_273 /* JSONEncoder+Extensions.swift */; };
+		OBJ_880 /* KeyedDecodingContainerProtocol+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_274 /* KeyedDecodingContainerProtocol+Extensions.swift */; };
+		OBJ_881 /* OperatingSystemVersion+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_275 /* OperatingSystemVersion+Extensions.swift */; };
+		OBJ_882 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_276 /* Optional+Extensions.swift */; };
+		OBJ_883 /* Path+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_277 /* Path+Extensions.swift */; };
+		OBJ_884 /* ProcessInfo+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_278 /* ProcessInfo+Extensions.swift */; };
+		OBJ_885 /* Promise+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_279 /* Promise+Extensions.swift */; };
+		OBJ_886 /* RangeReplaceableCollection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_280 /* RangeReplaceableCollection+Extensions.swift */; };
+		OBJ_887 /* Sequence+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_281 /* Sequence+Extensions.swift */; };
+		OBJ_888 /* SingleValueDecodingContainer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_282 /* SingleValueDecodingContainer+Extensions.swift */; };
+		OBJ_889 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_283 /* String+Extensions.swift */; };
+		OBJ_890 /* UnkeyedDecodingContainer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_284 /* UnkeyedDecodingContainer+Extensions.swift */; };
+		OBJ_891 /* HTTPBodyEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_287 /* HTTPBodyEncoder.swift */; };
+		OBJ_892 /* HTTPBodyJSONEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_288 /* HTTPBodyJSONEncoder.swift */; };
+		OBJ_893 /* HTTPBodyURLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_289 /* HTTPBodyURLEncoder.swift */; };
+		OBJ_894 /* HTTPActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_290 /* HTTPActivityIndicator.swift */; };
+		OBJ_895 /* HTTPAnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_291 /* HTTPAnyEncodable.swift */; };
+		OBJ_896 /* HTTPError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_292 /* HTTPError.swift */; };
+		OBJ_897 /* HTTPErrorStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_293 /* HTTPErrorStringConvertible.swift */; };
+		OBJ_898 /* HTTPHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_294 /* HTTPHeader.swift */; };
+		OBJ_899 /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_295 /* HTTPMethod.swift */; };
+		OBJ_900 /* HTTPResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_296 /* HTTPResponse.swift */; };
+		OBJ_901 /* HTTPRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_297 /* HTTPRoute.swift */; };
+		OBJ_902 /* HTTPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_298 /* HTTPService.swift */; };
+		OBJ_903 /* HTTPServiceTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_299 /* HTTPServiceTask.swift */; };
+		OBJ_904 /* HTTPStatusCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_300 /* HTTPStatusCode.swift */; };
+		OBJ_905 /* HTTPTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_301 /* HTTPTask.swift */; };
+		OBJ_906 /* HTTPUIActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_302 /* HTTPUIActivityIndicator.swift */; };
+		OBJ_907 /* HTTPQueryEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_304 /* HTTPQueryEncoder.swift */; };
+		OBJ_908 /* HTTPQueryURLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_305 /* HTTPQueryURLEncoder.swift */; };
+		OBJ_909 /* HTTPDataResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_307 /* HTTPDataResponseSerializer.swift */; };
+		OBJ_910 /* HTTPDecodableResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_308 /* HTTPDecodableResponseSerializer.swift */; };
+		OBJ_911 /* HTTPEmptyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_309 /* HTTPEmptyResponse.swift */; };
+		OBJ_912 /* HTTPJSONResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_310 /* HTTPJSONResponseSerializer.swift */; };
+		OBJ_913 /* HTTPResponseDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_311 /* HTTPResponseDecoder.swift */; };
+		OBJ_914 /* HTTPResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_312 /* HTTPResponseSerializer.swift */; };
+		OBJ_915 /* HTTPStringResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_313 /* HTTPStringResponseSerializer.swift */; };
+		OBJ_916 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_315 /* AnyCodable.swift */; };
+		OBJ_917 /* AnyCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_316 /* AnyCodingKey.swift */; };
+		OBJ_918 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_317 /* Cache.swift */; };
+		OBJ_919 /* MessageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_318 /* MessageError.swift */; };
+		OBJ_920 /* URLArrayEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_320 /* URLArrayEncodingStrategy.swift */; };
+		OBJ_921 /* URLBoolEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_321 /* URLBoolEncodingStrategy.swift */; };
+		OBJ_922 /* URLDateEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_322 /* URLDateEncodingStrategy.swift */; };
+		OBJ_923 /* URLEncodedForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_323 /* URLEncodedForm.swift */; };
+		OBJ_924 /* URLEncodedFormComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_324 /* URLEncodedFormComponent.swift */; };
+		OBJ_925 /* URLEncodedFormContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_325 /* URLEncodedFormContext.swift */; };
+		OBJ_926 /* URLEncodedFormEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_326 /* URLEncodedFormEncoder.swift */; };
+		OBJ_927 /* URLEncodedFormKeyedEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_327 /* URLEncodedFormKeyedEncodingContainer.swift */; };
+		OBJ_928 /* URLEncodedFormSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_328 /* URLEncodedFormSerializer.swift */; };
+		OBJ_929 /* URLEncodedFormSingleValueEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_329 /* URLEncodedFormSingleValueEncodingContainer.swift */; };
+		OBJ_930 /* URLEncodedFormUnkeyedEncodingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_330 /* URLEncodedFormUnkeyedEncodingContainer.swift */; };
+		OBJ_931 /* URLEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_331 /* URLEncoder.swift */; };
+		OBJ_932 /* URLSpaceEncodingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_332 /* URLSpaceEncodingStrategy.swift */; };
+		OBJ_934 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PromiseKit::PromiseKit::Product" /* PromiseKit.framework */; };
+		OBJ_935 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PathKit::PathKit::Product" /* PathKit.framework */; };
+		OBJ_936 /* SwiftCLI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftCLI::SwiftCLI::Product" /* SwiftCLI.framework */; };
+		OBJ_944 /* FugenToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_340 /* FugenToolsTests.swift */; };
+		OBJ_945 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_341 /* XCTestManifests.swift */; };
+		OBJ_947 /* FugenTools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Fugen::FugenTools::Product" /* FugenTools.framework */; };
+		OBJ_948 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PromiseKit::PromiseKit::Product" /* PromiseKit.framework */; };
+		OBJ_949 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "PathKit::PathKit::Product" /* PathKit.framework */; };
+		OBJ_950 /* SwiftCLI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "SwiftCLI::SwiftCLI::Product" /* SwiftCLI.framework */; };
+		OBJ_959 /* PathKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_431 /* PathKit.swift */; };
+		OBJ_966 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_430 /* Package.swift */; };
+		OBJ_971 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_378 /* Box.swift */; };
+		OBJ_972 /* Catchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_379 /* Catchable.swift */; };
+		OBJ_973 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_380 /* Configuration.swift */; };
+		OBJ_974 /* CustomStringConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_381 /* CustomStringConvertible.swift */; };
+		OBJ_975 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_382 /* Error.swift */; };
+		OBJ_976 /* Guarantee.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_383 /* Guarantee.swift */; };
+		OBJ_977 /* LogEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_384 /* LogEvent.swift */; };
+		OBJ_978 /* Promise.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_385 /* Promise.swift */; };
+		OBJ_979 /* Resolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_386 /* Resolver.swift */; };
+		OBJ_980 /* Thenable.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_387 /* Thenable.swift */; };
+		OBJ_981 /* after.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_388 /* after.swift */; };
+		OBJ_982 /* firstly.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_389 /* firstly.swift */; };
+		OBJ_983 /* hang.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_390 /* hang.swift */; };
+		OBJ_984 /* race.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_391 /* race.swift */; };
+		OBJ_985 /* when.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_392 /* when.swift */; };
+		OBJ_992 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_377 /* Package.swift */; };
+		OBJ_997 /* BackgroundColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_464 /* BackgroundColor.swift */; };
+		OBJ_998 /* CodesParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_465 /* CodesParser.swift */; };
+		OBJ_999 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_466 /* Color.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		C042746524E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E532003253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "DictionaryCoder::DictionaryCoder";
 			remoteInfo = DictionaryCoder;
 		};
-		C042746624E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E532004253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "StencilSwiftKit::StencilSwiftKit";
 			remoteInfo = StencilSwiftKit;
 		};
-		C042746724E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E532005253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Stencil::Stencil";
 			remoteInfo = Stencil;
 		};
-		C042746824E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E532006253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "PathKit::PathKit";
 			remoteInfo = PathKit;
 		};
-		C042746924E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E532007253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "PathKit::PathKit";
 			remoteInfo = PathKit;
 		};
-		C042746A24E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E532008253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Stencil::Stencil";
 			remoteInfo = Stencil;
 		};
-		C042746B24E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E532009253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Rainbow::Rainbow";
 			remoteInfo = Rainbow;
 		};
-		C042746C24E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E53200A253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Yams::Yams";
 			remoteInfo = Yams;
 		};
-		C042746D24E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E53200B253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Yams::CYaml";
 			remoteInfo = CYaml;
 		};
-		C042746E24E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E53200C253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Yams::CYaml";
 			remoteInfo = CYaml;
 		};
-		C042746F24E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E53200D253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Fugen::FugenTools";
 			remoteInfo = FugenTools;
 		};
-		C042747024E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E53200E253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "PromiseKit::PromiseKit";
 			remoteInfo = PromiseKit;
 		};
-		C042747124E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E53200F253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "PathKit::PathKit";
 			remoteInfo = PathKit;
 		};
-		C042747224E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E532010253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "SwiftCLI::SwiftCLI";
 			remoteInfo = SwiftCLI;
 		};
-		C042747324E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E532011253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "PromiseKit::PromiseKit";
 			remoteInfo = PromiseKit;
 		};
-		C042747424E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E532012253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "PathKit::PathKit";
 			remoteInfo = PathKit;
 		};
-		C042747524E8499E00E1605C /* PBXContainerItemProxy */ = {
+		8E532013253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "SwiftCLI::SwiftCLI";
 			remoteInfo = SwiftCLI;
 		};
-		C042747624E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E532014253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Fugen::FugenTools";
 			remoteInfo = FugenTools;
 		};
-		C042747724E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E532015253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "PromiseKit::PromiseKit";
 			remoteInfo = PromiseKit;
 		};
-		C042747824E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E532016253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "PathKit::PathKit";
 			remoteInfo = PathKit;
 		};
-		C042747924E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E532017253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "SwiftCLI::SwiftCLI";
 			remoteInfo = SwiftCLI;
 		};
-		C042747A24E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E532018253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Fugen::Fugen";
 			remoteInfo = Fugen;
 		};
-		C042747B24E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E532019253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "DictionaryCoder::DictionaryCoder";
 			remoteInfo = DictionaryCoder;
 		};
-		C042747C24E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E53201A253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "StencilSwiftKit::StencilSwiftKit";
 			remoteInfo = StencilSwiftKit;
 		};
-		C042747D24E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E53201B253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Stencil::Stencil";
 			remoteInfo = Stencil;
 		};
-		C042747E24E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E53201C253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Rainbow::Rainbow";
 			remoteInfo = Rainbow;
 		};
-		C042747F24E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E53201D253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Yams::Yams";
 			remoteInfo = Yams;
 		};
-		C042748024E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E53201E253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Yams::CYaml";
 			remoteInfo = CYaml;
 		};
-		C042748124E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E53201F253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Fugen::FugenTools";
 			remoteInfo = FugenTools;
 		};
-		C042748224E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E532020253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "PromiseKit::PromiseKit";
 			remoteInfo = PromiseKit;
 		};
-		C042748324E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E532021253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "PathKit::PathKit";
 			remoteInfo = PathKit;
 		};
-		C042748424E8499F00E1605C /* PBXContainerItemProxy */ = {
+		8E532022253303C9006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "SwiftCLI::SwiftCLI";
 			remoteInfo = SwiftCLI;
 		};
-		C042748524E849A000E1605C /* PBXContainerItemProxy */ = {
+		8E532028253303CB006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Fugen::FugenTests";
 			remoteInfo = FugenTests;
 		};
-		C042748624E849A000E1605C /* PBXContainerItemProxy */ = {
+		8E532029253303CB006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "Fugen::FugenToolsTests";
 			remoteInfo = FugenToolsTests;
 		};
-		C042748724E849A000E1605C /* PBXContainerItemProxy */ = {
+		8E53203C253303CB006AA460 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
@@ -731,413 +736,411 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		C01B801A24FFF78B0080227E /* ShadowType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowType.swift; sourceTree = "<group>"; };
-		C042748824E84B3B00E1605C /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = SOURCE_ROOT; };
-		C042748924E84B3B00E1605C /* .ruby-version */ = {isa = PBXFileReference; lastKnownFileType = text; path = ".ruby-version"; sourceTree = SOURCE_ROOT; };
-		C042748A24E84B3B00E1605C /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = SOURCE_ROOT; };
-		C042748B24E84B3B00E1605C /* .swift-version */ = {isa = PBXFileReference; lastKnownFileType = text; path = ".swift-version"; sourceTree = SOURCE_ROOT; };
-		C042748C24E84B5600E1605C /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
-		C042748D24E84B6D00E1605C /* LinuxMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LinuxMain.swift; path = Tests/LinuxMain.swift; sourceTree = "<group>"; };
-		C042748E24E84B8800E1605C /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; name = .swiftlint.yml; path = Tests/.swiftlint.yml; sourceTree = "<group>"; };
-		C0BE783424E94735004EBBEF /* Shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shadow.swift; sourceTree = "<group>"; };
-		C0BE783624E95650004EBBEF /* TextStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextStyle.swift; sourceTree = "<group>"; };
-		C0BE783B24E9B26E004EBBEF /* StencilVectorFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilVectorFilter.swift; sourceTree = "<group>"; };
-		C0BE783D24E9B2E8004EBBEF /* StencilVectorInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilVectorInfoFilter.swift; sourceTree = "<group>"; };
+		8E53203E25330481006AA460 /* StencilModificator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StencilModificator.swift; sourceTree = "<group>"; };
+		8E53203F25330481006AA460 /* StencilModificatorError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StencilModificatorError.swift; sourceTree = "<group>"; };
+		8E53205A25330490006AA460 /* StencilFontModificator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StencilFontModificator.swift; sourceTree = "<group>"; };
+		8E53205B25330490006AA460 /* StencilFontInitializerModificator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StencilFontInitializerModificator.swift; sourceTree = "<group>"; };
+		8E5320A625335F8A006AA460 /* StencilFontSystemFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilFontSystemFilter.swift; sourceTree = "<group>"; };
 		"DictionaryCoder::DictionaryCoder::Product" /* DictionaryCoder.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = DictionaryCoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Fugen::Fugen::Product" /* Fugen */ = {isa = PBXFileReference; lastKnownFileType = text; path = Fugen; sourceTree = BUILT_PRODUCTS_DIR; };
-		"Fugen::FugenTests::Product" /* FugenTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = FugenTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"Fugen::FugenTests::Product" /* FugenTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = FugenTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Fugen::FugenTools::Product" /* FugenTools.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FugenTools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Fugen::FugenToolsTests::Product" /* FugenToolsTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = FugenToolsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_10 /* AsyncExecutableCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncExecutableCommand.swift; sourceTree = "<group>"; };
-		OBJ_101 /* FigmaBlendMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaBlendMode.swift; sourceTree = "<group>"; };
-		OBJ_102 /* FigmaBooleanOperationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaBooleanOperationType.swift; sourceTree = "<group>"; };
-		OBJ_103 /* FigmaColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaColor.swift; sourceTree = "<group>"; };
-		OBJ_104 /* FigmaColorStop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaColorStop.swift; sourceTree = "<group>"; };
-		OBJ_105 /* FigmaComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaComponent.swift; sourceTree = "<group>"; };
-		OBJ_106 /* FigmaConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaConstraint.swift; sourceTree = "<group>"; };
-		OBJ_107 /* FigmaConstraintType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaConstraintType.swift; sourceTree = "<group>"; };
-		OBJ_108 /* FigmaEasingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaEasingType.swift; sourceTree = "<group>"; };
-		OBJ_109 /* FigmaEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaEffect.swift; sourceTree = "<group>"; };
+		OBJ_100 /* FigmaError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaError.swift; sourceTree = "<group>"; };
+		OBJ_101 /* FigmaImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaImages.swift; sourceTree = "<group>"; };
+		OBJ_103 /* FigmaBlendMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaBlendMode.swift; sourceTree = "<group>"; };
+		OBJ_104 /* FigmaBooleanOperationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaBooleanOperationType.swift; sourceTree = "<group>"; };
+		OBJ_105 /* FigmaColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaColor.swift; sourceTree = "<group>"; };
+		OBJ_106 /* FigmaColorStop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaColorStop.swift; sourceTree = "<group>"; };
+		OBJ_107 /* FigmaComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaComponent.swift; sourceTree = "<group>"; };
+		OBJ_108 /* FigmaConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaConstraint.swift; sourceTree = "<group>"; };
+		OBJ_109 /* FigmaConstraintType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaConstraintType.swift; sourceTree = "<group>"; };
 		OBJ_11 /* ColorStylesCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStylesCommand.swift; sourceTree = "<group>"; };
-		OBJ_110 /* FigmaEffectType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaEffectType.swift; sourceTree = "<group>"; };
-		OBJ_111 /* FigmaExportSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaExportSetting.swift; sourceTree = "<group>"; };
-		OBJ_112 /* FigmaFrameOffset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaFrameOffset.swift; sourceTree = "<group>"; };
-		OBJ_113 /* FigmaImageFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaImageFormat.swift; sourceTree = "<group>"; };
-		OBJ_114 /* FigmaLayoutConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLayoutConstraint.swift; sourceTree = "<group>"; };
-		OBJ_115 /* FigmaLayoutGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLayoutGrid.swift; sourceTree = "<group>"; };
-		OBJ_116 /* FigmaLayoutGridAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLayoutGridAlignment.swift; sourceTree = "<group>"; };
-		OBJ_117 /* FigmaLayoutGridPattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLayoutGridPattern.swift; sourceTree = "<group>"; };
-		OBJ_118 /* FigmaLayoutHorizontalConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLayoutHorizontalConstraint.swift; sourceTree = "<group>"; };
-		OBJ_119 /* FigmaLayoutVerticalConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLayoutVerticalConstraint.swift; sourceTree = "<group>"; };
+		OBJ_110 /* FigmaEasingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaEasingType.swift; sourceTree = "<group>"; };
+		OBJ_111 /* FigmaEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaEffect.swift; sourceTree = "<group>"; };
+		OBJ_112 /* FigmaEffectType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaEffectType.swift; sourceTree = "<group>"; };
+		OBJ_113 /* FigmaExportSetting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaExportSetting.swift; sourceTree = "<group>"; };
+		OBJ_114 /* FigmaFrameOffset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaFrameOffset.swift; sourceTree = "<group>"; };
+		OBJ_115 /* FigmaImageFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaImageFormat.swift; sourceTree = "<group>"; };
+		OBJ_116 /* FigmaLayoutConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLayoutConstraint.swift; sourceTree = "<group>"; };
+		OBJ_117 /* FigmaLayoutGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLayoutGrid.swift; sourceTree = "<group>"; };
+		OBJ_118 /* FigmaLayoutGridAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLayoutGridAlignment.swift; sourceTree = "<group>"; };
+		OBJ_119 /* FigmaLayoutGridPattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLayoutGridPattern.swift; sourceTree = "<group>"; };
 		OBJ_12 /* GenerateCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateCommand.swift; sourceTree = "<group>"; };
-		OBJ_120 /* FigmaLineHeightUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLineHeightUnit.swift; sourceTree = "<group>"; };
-		OBJ_121 /* FigmaPaint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaPaint.swift; sourceTree = "<group>"; };
-		OBJ_122 /* FigmaPaintType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaPaintType.swift; sourceTree = "<group>"; };
-		OBJ_123 /* FigmaRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaRectangle.swift; sourceTree = "<group>"; };
-		OBJ_124 /* FigmaScaleMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaScaleMode.swift; sourceTree = "<group>"; };
-		OBJ_125 /* FigmaStrokeAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaStrokeAlignment.swift; sourceTree = "<group>"; };
-		OBJ_126 /* FigmaStrokeCap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaStrokeCap.swift; sourceTree = "<group>"; };
-		OBJ_127 /* FigmaStrokeJoin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaStrokeJoin.swift; sourceTree = "<group>"; };
-		OBJ_128 /* FigmaStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaStyle.swift; sourceTree = "<group>"; };
-		OBJ_129 /* FigmaStyleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaStyleType.swift; sourceTree = "<group>"; };
+		OBJ_120 /* FigmaLayoutHorizontalConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLayoutHorizontalConstraint.swift; sourceTree = "<group>"; };
+		OBJ_121 /* FigmaLayoutVerticalConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLayoutVerticalConstraint.swift; sourceTree = "<group>"; };
+		OBJ_122 /* FigmaLineHeightUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaLineHeightUnit.swift; sourceTree = "<group>"; };
+		OBJ_123 /* FigmaPaint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaPaint.swift; sourceTree = "<group>"; };
+		OBJ_124 /* FigmaPaintType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaPaintType.swift; sourceTree = "<group>"; };
+		OBJ_125 /* FigmaRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaRectangle.swift; sourceTree = "<group>"; };
+		OBJ_126 /* FigmaScaleMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaScaleMode.swift; sourceTree = "<group>"; };
+		OBJ_127 /* FigmaStrokeAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaStrokeAlignment.swift; sourceTree = "<group>"; };
+		OBJ_128 /* FigmaStrokeCap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaStrokeCap.swift; sourceTree = "<group>"; };
+		OBJ_129 /* FigmaStrokeJoin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaStrokeJoin.swift; sourceTree = "<group>"; };
 		OBJ_13 /* GenerationConfigurableCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationConfigurableCommand.swift; sourceTree = "<group>"; };
-		OBJ_130 /* FigmaTextCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaTextCase.swift; sourceTree = "<group>"; };
-		OBJ_131 /* FigmaTextDecoration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaTextDecoration.swift; sourceTree = "<group>"; };
-		OBJ_132 /* FigmaTextHorizontalAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaTextHorizontalAlignment.swift; sourceTree = "<group>"; };
-		OBJ_133 /* FigmaTextVerticalAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaTextVerticalAlignment.swift; sourceTree = "<group>"; };
-		OBJ_134 /* FigmaTypeStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaTypeStyle.swift; sourceTree = "<group>"; };
-		OBJ_135 /* FigmaVector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaVector.swift; sourceTree = "<group>"; };
-		OBJ_137 /* FigmaBooleanOperationNodePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaBooleanOperationNodePayload.swift; sourceTree = "<group>"; };
-		OBJ_138 /* FigmaCanvasNodeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaCanvasNodeInfo.swift; sourceTree = "<group>"; };
-		OBJ_139 /* FigmaDocumentNodeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaDocumentNodeInfo.swift; sourceTree = "<group>"; };
+		OBJ_130 /* FigmaStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaStyle.swift; sourceTree = "<group>"; };
+		OBJ_131 /* FigmaStyleType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaStyleType.swift; sourceTree = "<group>"; };
+		OBJ_132 /* FigmaTextCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaTextCase.swift; sourceTree = "<group>"; };
+		OBJ_133 /* FigmaTextDecoration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaTextDecoration.swift; sourceTree = "<group>"; };
+		OBJ_134 /* FigmaTextHorizontalAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaTextHorizontalAlignment.swift; sourceTree = "<group>"; };
+		OBJ_135 /* FigmaTextVerticalAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaTextVerticalAlignment.swift; sourceTree = "<group>"; };
+		OBJ_136 /* FigmaTypeStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaTypeStyle.swift; sourceTree = "<group>"; };
+		OBJ_137 /* FigmaVector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaVector.swift; sourceTree = "<group>"; };
+		OBJ_139 /* FigmaBooleanOperationNodePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaBooleanOperationNodePayload.swift; sourceTree = "<group>"; };
 		OBJ_14 /* ImagesCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesCommand.swift; sourceTree = "<group>"; };
-		OBJ_140 /* FigmaFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaFile.swift; sourceTree = "<group>"; };
-		OBJ_141 /* FigmaFrameNodeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaFrameNodeInfo.swift; sourceTree = "<group>"; };
-		OBJ_142 /* FigmaInstanceNodePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaInstanceNodePayload.swift; sourceTree = "<group>"; };
-		OBJ_143 /* FigmaNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaNode.swift; sourceTree = "<group>"; };
-		OBJ_144 /* FigmaNodeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaNodeType.swift; sourceTree = "<group>"; };
-		OBJ_145 /* FigmaRectangleNodePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaRectangleNodePayload.swift; sourceTree = "<group>"; };
-		OBJ_146 /* FigmaSliceNodeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaSliceNodeInfo.swift; sourceTree = "<group>"; };
-		OBJ_147 /* FigmaTextNodePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaTextNodePayload.swift; sourceTree = "<group>"; };
-		OBJ_148 /* FigmaVectorNodeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaVectorNodeInfo.swift; sourceTree = "<group>"; };
-		OBJ_149 /* DefaultFigmaAPIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFigmaAPIProvider.swift; sourceTree = "<group>"; };
+		OBJ_140 /* FigmaCanvasNodeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaCanvasNodeInfo.swift; sourceTree = "<group>"; };
+		OBJ_141 /* FigmaDocumentNodeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaDocumentNodeInfo.swift; sourceTree = "<group>"; };
+		OBJ_142 /* FigmaFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaFile.swift; sourceTree = "<group>"; };
+		OBJ_143 /* FigmaFrameNodeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaFrameNodeInfo.swift; sourceTree = "<group>"; };
+		OBJ_144 /* FigmaInstanceNodePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaInstanceNodePayload.swift; sourceTree = "<group>"; };
+		OBJ_145 /* FigmaNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaNode.swift; sourceTree = "<group>"; };
+		OBJ_146 /* FigmaNodeType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaNodeType.swift; sourceTree = "<group>"; };
+		OBJ_147 /* FigmaRectangleNodePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaRectangleNodePayload.swift; sourceTree = "<group>"; };
+		OBJ_148 /* FigmaSliceNodeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaSliceNodeInfo.swift; sourceTree = "<group>"; };
+		OBJ_149 /* FigmaTextNodePayload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaTextNodePayload.swift; sourceTree = "<group>"; };
 		OBJ_15 /* ShadowStylesCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStylesCommand.swift; sourceTree = "<group>"; };
-		OBJ_150 /* FigmaAPIEmptyParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIEmptyParameters.swift; sourceTree = "<group>"; };
-		OBJ_151 /* FigmaAPIEmptyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIEmptyResponse.swift; sourceTree = "<group>"; };
-		OBJ_152 /* FigmaAPIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIProvider.swift; sourceTree = "<group>"; };
-		OBJ_153 /* FigmaAPIRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIRoute.swift; sourceTree = "<group>"; };
-		OBJ_154 /* FigmaAPIVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIVersion.swift; sourceTree = "<group>"; };
-		OBJ_155 /* FigmaHTTPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaHTTPService.swift; sourceTree = "<group>"; };
-		OBJ_157 /* FigmaAPIFileRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIFileRoute.swift; sourceTree = "<group>"; };
-		OBJ_158 /* FigmaAPIFileRouteQueryParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIFileRouteQueryParameters.swift; sourceTree = "<group>"; };
-		OBJ_159 /* FigmaAPIImagesRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIImagesRoute.swift; sourceTree = "<group>"; };
+		OBJ_150 /* FigmaVectorNodeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaVectorNodeInfo.swift; sourceTree = "<group>"; };
+		OBJ_151 /* DefaultFigmaAPIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFigmaAPIProvider.swift; sourceTree = "<group>"; };
+		OBJ_152 /* FigmaAPIEmptyParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIEmptyParameters.swift; sourceTree = "<group>"; };
+		OBJ_153 /* FigmaAPIEmptyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIEmptyResponse.swift; sourceTree = "<group>"; };
+		OBJ_154 /* FigmaAPIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIProvider.swift; sourceTree = "<group>"; };
+		OBJ_155 /* FigmaAPIRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIRoute.swift; sourceTree = "<group>"; };
+		OBJ_156 /* FigmaAPIVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIVersion.swift; sourceTree = "<group>"; };
+		OBJ_157 /* FigmaHTTPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaHTTPService.swift; sourceTree = "<group>"; };
+		OBJ_159 /* FigmaAPIFileRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIFileRoute.swift; sourceTree = "<group>"; };
 		OBJ_16 /* TextStylesCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStylesCommand.swift; sourceTree = "<group>"; };
-		OBJ_160 /* FigmaAPIImagesRouteQueryParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIImagesRouteQueryParameters.swift; sourceTree = "<group>"; };
-		OBJ_162 /* DefaultFigmaFilesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFigmaFilesProvider.swift; sourceTree = "<group>"; };
-		OBJ_163 /* FigmaFilesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaFilesProvider.swift; sourceTree = "<group>"; };
-		OBJ_165 /* DefaultFigmaNodesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFigmaNodesProvider.swift; sourceTree = "<group>"; };
-		OBJ_166 /* FigmaNodesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaNodesProvider.swift; sourceTree = "<group>"; };
-		OBJ_167 /* FigmaNodesProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaNodesProviderError.swift; sourceTree = "<group>"; };
+		OBJ_160 /* FigmaAPIFileRouteQueryParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIFileRouteQueryParameters.swift; sourceTree = "<group>"; };
+		OBJ_161 /* FigmaAPIImagesRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIImagesRoute.swift; sourceTree = "<group>"; };
+		OBJ_162 /* FigmaAPIImagesRouteQueryParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaAPIImagesRouteQueryParameters.swift; sourceTree = "<group>"; };
+		OBJ_164 /* DefaultFigmaFilesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFigmaFilesProvider.swift; sourceTree = "<group>"; };
+		OBJ_165 /* FigmaFilesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaFilesProvider.swift; sourceTree = "<group>"; };
+		OBJ_167 /* DefaultFigmaNodesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFigmaNodesProvider.swift; sourceTree = "<group>"; };
+		OBJ_168 /* FigmaNodesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaNodesProvider.swift; sourceTree = "<group>"; };
+		OBJ_169 /* FigmaNodesProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaNodesProviderError.swift; sourceTree = "<group>"; };
 		OBJ_17 /* Dependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dependencies.swift; sourceTree = "<group>"; };
-		OBJ_170 /* DefaultImageAssetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageAssetsProvider.swift; sourceTree = "<group>"; };
-		OBJ_171 /* ImageAssetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAssetsProvider.swift; sourceTree = "<group>"; };
-		OBJ_172 /* DefaultImagesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImagesProvider.swift; sourceTree = "<group>"; };
-		OBJ_173 /* ImagesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesProvider.swift; sourceTree = "<group>"; };
-		OBJ_174 /* ImagesProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesProviderError.swift; sourceTree = "<group>"; };
-		OBJ_176 /* DefaultImageRenderProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageRenderProvider.swift; sourceTree = "<group>"; };
-		OBJ_177 /* ImageRenderProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRenderProvider.swift; sourceTree = "<group>"; };
-		OBJ_178 /* ImageRenderProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRenderProviderError.swift; sourceTree = "<group>"; };
-		OBJ_180 /* DefaultImageResourcesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageResourcesProvider.swift; sourceTree = "<group>"; };
-		OBJ_181 /* ImageResourcesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageResourcesProvider.swift; sourceTree = "<group>"; };
-		OBJ_183 /* DefaultShadowStylesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultShadowStylesProvider.swift; sourceTree = "<group>"; };
-		OBJ_184 /* ShadowStylesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStylesProvider.swift; sourceTree = "<group>"; };
-		OBJ_185 /* ShadowStylesProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStylesProviderError.swift; sourceTree = "<group>"; };
-		OBJ_187 /* DefaultTextStylesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTextStylesProvider.swift; sourceTree = "<group>"; };
-		OBJ_188 /* TextStylesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStylesProvider.swift; sourceTree = "<group>"; };
-		OBJ_189 /* TextStylesProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStylesProviderError.swift; sourceTree = "<group>"; };
-		OBJ_191 /* DefaultTemplateContextCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTemplateContextCoder.swift; sourceTree = "<group>"; };
-		OBJ_192 /* DefaultTemplateRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTemplateRenderer.swift; sourceTree = "<group>"; };
-		OBJ_193 /* RenderDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderDestination.swift; sourceTree = "<group>"; };
-		OBJ_194 /* RenderTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderTemplate.swift; sourceTree = "<group>"; };
-		OBJ_195 /* RenderTemplateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderTemplateType.swift; sourceTree = "<group>"; };
-		OBJ_198 /* StencilColorFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilColorFilter.swift; sourceTree = "<group>"; };
-		OBJ_199 /* StencilColorInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilColorInfoFilter.swift; sourceTree = "<group>"; };
+		OBJ_172 /* DefaultImageAssetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageAssetsProvider.swift; sourceTree = "<group>"; };
+		OBJ_173 /* ImageAssetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAssetsProvider.swift; sourceTree = "<group>"; };
+		OBJ_174 /* DefaultImagesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImagesProvider.swift; sourceTree = "<group>"; };
+		OBJ_175 /* ImagesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesProvider.swift; sourceTree = "<group>"; };
+		OBJ_176 /* ImagesProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesProviderError.swift; sourceTree = "<group>"; };
+		OBJ_178 /* DefaultImageRenderProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageRenderProvider.swift; sourceTree = "<group>"; };
+		OBJ_179 /* ImageRenderProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRenderProvider.swift; sourceTree = "<group>"; };
+		OBJ_180 /* ImageRenderProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageRenderProviderError.swift; sourceTree = "<group>"; };
+		OBJ_182 /* DefaultImageResourcesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImageResourcesProvider.swift; sourceTree = "<group>"; };
+		OBJ_183 /* ImageResourcesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageResourcesProvider.swift; sourceTree = "<group>"; };
+		OBJ_185 /* DefaultShadowStylesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultShadowStylesProvider.swift; sourceTree = "<group>"; };
+		OBJ_186 /* ShadowStylesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStylesProvider.swift; sourceTree = "<group>"; };
+		OBJ_187 /* ShadowStylesProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStylesProviderError.swift; sourceTree = "<group>"; };
+		OBJ_189 /* DefaultTextStylesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTextStylesProvider.swift; sourceTree = "<group>"; };
+		OBJ_190 /* TextStylesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStylesProvider.swift; sourceTree = "<group>"; };
+		OBJ_191 /* TextStylesProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStylesProviderError.swift; sourceTree = "<group>"; };
+		OBJ_193 /* DefaultTemplateContextCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTemplateContextCoder.swift; sourceTree = "<group>"; };
+		OBJ_194 /* DefaultTemplateRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTemplateRenderer.swift; sourceTree = "<group>"; };
+		OBJ_195 /* RenderDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderDestination.swift; sourceTree = "<group>"; };
+		OBJ_196 /* RenderTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderTemplate.swift; sourceTree = "<group>"; };
+		OBJ_197 /* RenderTemplateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderTemplateType.swift; sourceTree = "<group>"; };
 		OBJ_20 /* ColorStylesContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStylesContext.swift; sourceTree = "<group>"; };
-		OBJ_200 /* StencilColorRGBAHexInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilColorRGBAHexInfoFilter.swift; sourceTree = "<group>"; };
-		OBJ_201 /* StencilColorRGBAInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilColorRGBAInfoFilter.swift; sourceTree = "<group>"; };
-		OBJ_202 /* StencilColorRGBHexInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilColorRGBHexInfoFilter.swift; sourceTree = "<group>"; };
-		OBJ_203 /* StencilColorRGBInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilColorRGBInfoFilter.swift; sourceTree = "<group>"; };
-		OBJ_205 /* StencilFontFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilFontFilter.swift; sourceTree = "<group>"; };
-		OBJ_206 /* StencilFontInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilFontInfoFilter.swift; sourceTree = "<group>"; };
-		OBJ_208 /* StencilByteToFloatFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilByteToFloatFilter.swift; sourceTree = "<group>"; };
-		OBJ_209 /* StencilByteToHexFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilByteToHexFilter.swift; sourceTree = "<group>"; };
+		OBJ_200 /* StencilColorFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilColorFilter.swift; sourceTree = "<group>"; };
+		OBJ_201 /* StencilColorInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilColorInfoFilter.swift; sourceTree = "<group>"; };
+		OBJ_202 /* StencilColorRGBAHexInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilColorRGBAHexInfoFilter.swift; sourceTree = "<group>"; };
+		OBJ_203 /* StencilColorRGBAInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilColorRGBAInfoFilter.swift; sourceTree = "<group>"; };
+		OBJ_204 /* StencilColorRGBHexInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilColorRGBHexInfoFilter.swift; sourceTree = "<group>"; };
+		OBJ_205 /* StencilColorRGBInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilColorRGBInfoFilter.swift; sourceTree = "<group>"; };
+		OBJ_207 /* StencilFontFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilFontFilter.swift; sourceTree = "<group>"; };
+		OBJ_208 /* StencilFontInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilFontInfoFilter.swift; sourceTree = "<group>"; };
 		OBJ_21 /* ColorStylesGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStylesGenerator.swift; sourceTree = "<group>"; };
-		OBJ_210 /* StencilFloatToByteFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilFloatToByteFilter.swift; sourceTree = "<group>"; };
-		OBJ_211 /* StencilHexToByteFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilHexToByteFilter.swift; sourceTree = "<group>"; };
-		OBJ_212 /* StencilExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilExtension.swift; sourceTree = "<group>"; };
-		OBJ_213 /* StencilFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilFilter.swift; sourceTree = "<group>"; };
-		OBJ_214 /* StencilFilterError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilFilterError.swift; sourceTree = "<group>"; };
-		OBJ_215 /* StencilTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilTag.swift; sourceTree = "<group>"; };
-		OBJ_216 /* StencilTagError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilTagError.swift; sourceTree = "<group>"; };
-		OBJ_217 /* StencilTagNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilTagNode.swift; sourceTree = "<group>"; };
-		OBJ_218 /* TemplateContextCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateContextCoder.swift; sourceTree = "<group>"; };
-		OBJ_219 /* TemplateRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateRenderer.swift; sourceTree = "<group>"; };
+		OBJ_210 /* StencilByteToFloatFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilByteToFloatFilter.swift; sourceTree = "<group>"; };
+		OBJ_211 /* StencilByteToHexFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilByteToHexFilter.swift; sourceTree = "<group>"; };
+		OBJ_212 /* StencilFloatToByteFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilFloatToByteFilter.swift; sourceTree = "<group>"; };
+		OBJ_213 /* StencilHexToByteFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilHexToByteFilter.swift; sourceTree = "<group>"; };
+		OBJ_214 /* StencilExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilExtension.swift; sourceTree = "<group>"; };
+		OBJ_215 /* StencilFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilFilter.swift; sourceTree = "<group>"; };
+		OBJ_216 /* StencilFilterError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilFilterError.swift; sourceTree = "<group>"; };
+		OBJ_217 /* StencilTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilTag.swift; sourceTree = "<group>"; };
+		OBJ_218 /* StencilTagError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilTagError.swift; sourceTree = "<group>"; };
+		OBJ_219 /* StencilTagNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilTagNode.swift; sourceTree = "<group>"; };
 		OBJ_22 /* DefaultColorStylesGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultColorStylesGenerator.swift; sourceTree = "<group>"; };
-		OBJ_220 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
-		OBJ_223 /* AssetAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAppearance.swift; sourceTree = "<group>"; };
-		OBJ_224 /* AssetAppearanceContrast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAppearanceContrast.swift; sourceTree = "<group>"; };
-		OBJ_225 /* AssetAppearanceLuminosity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAppearanceLuminosity.swift; sourceTree = "<group>"; };
-		OBJ_226 /* AssetCompressionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetCompressionType.swift; sourceTree = "<group>"; };
-		OBJ_227 /* AssetDisplayGamut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetDisplayGamut.swift; sourceTree = "<group>"; };
-		OBJ_228 /* AssetIdiom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetIdiom.swift; sourceTree = "<group>"; };
-		OBJ_229 /* AssetIdiomIPadSubtype.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetIdiomIPadSubtype.swift; sourceTree = "<group>"; };
+		OBJ_221 /* StencilVectorFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilVectorFilter.swift; sourceTree = "<group>"; };
+		OBJ_222 /* StencilVectorInfoFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilVectorInfoFilter.swift; sourceTree = "<group>"; };
+		OBJ_223 /* TemplateContextCoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateContextCoder.swift; sourceTree = "<group>"; };
+		OBJ_224 /* TemplateRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplateRenderer.swift; sourceTree = "<group>"; };
+		OBJ_225 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		OBJ_228 /* AssetAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAppearance.swift; sourceTree = "<group>"; };
+		OBJ_229 /* AssetAppearanceContrast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAppearanceContrast.swift; sourceTree = "<group>"; };
 		OBJ_23 /* GenerationParametersError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationParametersError.swift; sourceTree = "<group>"; };
-		OBJ_230 /* AssetInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetInfo.swift; sourceTree = "<group>"; };
-		OBJ_231 /* AssetNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetNode.swift; sourceTree = "<group>"; };
-		OBJ_233 /* AssetColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetColor.swift; sourceTree = "<group>"; };
-		OBJ_234 /* AssetColorComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetColorComponents.swift; sourceTree = "<group>"; };
-		OBJ_235 /* AssetColorContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetColorContent.swift; sourceTree = "<group>"; };
-		OBJ_236 /* AssetColorGrayscale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetColorGrayscale.swift; sourceTree = "<group>"; };
-		OBJ_237 /* AssetColorSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetColorSet.swift; sourceTree = "<group>"; };
-		OBJ_238 /* AssetColorSetContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetColorSetContents.swift; sourceTree = "<group>"; };
-		OBJ_239 /* AssetCustomColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetCustomColor.swift; sourceTree = "<group>"; };
+		OBJ_230 /* AssetAppearanceLuminosity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetAppearanceLuminosity.swift; sourceTree = "<group>"; };
+		OBJ_231 /* AssetCompressionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetCompressionType.swift; sourceTree = "<group>"; };
+		OBJ_232 /* AssetDisplayGamut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetDisplayGamut.swift; sourceTree = "<group>"; };
+		OBJ_233 /* AssetIdiom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetIdiom.swift; sourceTree = "<group>"; };
+		OBJ_234 /* AssetIdiomIPadSubtype.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetIdiomIPadSubtype.swift; sourceTree = "<group>"; };
+		OBJ_235 /* AssetInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetInfo.swift; sourceTree = "<group>"; };
+		OBJ_236 /* AssetNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetNode.swift; sourceTree = "<group>"; };
+		OBJ_238 /* AssetColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetColor.swift; sourceTree = "<group>"; };
+		OBJ_239 /* AssetColorComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetColorComponents.swift; sourceTree = "<group>"; };
 		OBJ_24 /* GenerationParametersResolving.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationParametersResolving.swift; sourceTree = "<group>"; };
-		OBJ_240 /* AssetSystemColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetSystemColor.swift; sourceTree = "<group>"; };
-		OBJ_241 /* AssetSystemColorPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetSystemColorPlatform.swift; sourceTree = "<group>"; };
-		OBJ_243 /* AssetFolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetFolder.swift; sourceTree = "<group>"; };
-		OBJ_244 /* AssetFolderContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetFolderContents.swift; sourceTree = "<group>"; };
-		OBJ_245 /* AssetFolderProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetFolderProperties.swift; sourceTree = "<group>"; };
-		OBJ_247 /* AssetImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImage.swift; sourceTree = "<group>"; };
-		OBJ_248 /* AssetImageAlignmentInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageAlignmentInsets.swift; sourceTree = "<group>"; };
-		OBJ_249 /* AssetImageAutoScaling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageAutoScaling.swift; sourceTree = "<group>"; };
-		OBJ_250 /* AssetImageGraphicsFeatureSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageGraphicsFeatureSet.swift; sourceTree = "<group>"; };
-		OBJ_251 /* AssetImageLanguageDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageLanguageDirection.swift; sourceTree = "<group>"; };
-		OBJ_252 /* AssetImageMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageMemory.swift; sourceTree = "<group>"; };
-		OBJ_253 /* AssetImageProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageProperties.swift; sourceTree = "<group>"; };
-		OBJ_254 /* AssetImageScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageScale.swift; sourceTree = "<group>"; };
-		OBJ_255 /* AssetImageSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageSet.swift; sourceTree = "<group>"; };
-		OBJ_256 /* AssetImageSetContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageSetContents.swift; sourceTree = "<group>"; };
-		OBJ_257 /* AssetImageSizeClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageSizeClass.swift; sourceTree = "<group>"; };
-		OBJ_258 /* AssetImageTemplateRenderingIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageTemplateRenderingIntent.swift; sourceTree = "<group>"; };
+		OBJ_240 /* AssetColorContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetColorContent.swift; sourceTree = "<group>"; };
+		OBJ_241 /* AssetColorGrayscale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetColorGrayscale.swift; sourceTree = "<group>"; };
+		OBJ_242 /* AssetColorSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetColorSet.swift; sourceTree = "<group>"; };
+		OBJ_243 /* AssetColorSetContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetColorSetContents.swift; sourceTree = "<group>"; };
+		OBJ_244 /* AssetCustomColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetCustomColor.swift; sourceTree = "<group>"; };
+		OBJ_245 /* AssetSystemColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetSystemColor.swift; sourceTree = "<group>"; };
+		OBJ_246 /* AssetSystemColorPlatform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetSystemColorPlatform.swift; sourceTree = "<group>"; };
+		OBJ_248 /* AssetFolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetFolder.swift; sourceTree = "<group>"; };
+		OBJ_249 /* AssetFolderContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetFolderContents.swift; sourceTree = "<group>"; };
+		OBJ_250 /* AssetFolderProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetFolderProperties.swift; sourceTree = "<group>"; };
+		OBJ_252 /* AssetImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImage.swift; sourceTree = "<group>"; };
+		OBJ_253 /* AssetImageAlignmentInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageAlignmentInsets.swift; sourceTree = "<group>"; };
+		OBJ_254 /* AssetImageAutoScaling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageAutoScaling.swift; sourceTree = "<group>"; };
+		OBJ_255 /* AssetImageGraphicsFeatureSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageGraphicsFeatureSet.swift; sourceTree = "<group>"; };
+		OBJ_256 /* AssetImageLanguageDirection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageLanguageDirection.swift; sourceTree = "<group>"; };
+		OBJ_257 /* AssetImageMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageMemory.swift; sourceTree = "<group>"; };
+		OBJ_258 /* AssetImageProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageProperties.swift; sourceTree = "<group>"; };
+		OBJ_259 /* AssetImageScale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageScale.swift; sourceTree = "<group>"; };
 		OBJ_26 /* DefaultImagesGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultImagesGenerator.swift; sourceTree = "<group>"; };
-		OBJ_260 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_261 /* CLI+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLI+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_262 /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_263 /* Decodable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_264 /* DispatchQueue+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_265 /* Encodable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_266 /* FloatingPoint+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FloatingPoint+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_267 /* JSONDecoder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONDecoder+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_268 /* JSONEncoder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONEncoder+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_269 /* KeyedDecodingContainerProtocol+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainerProtocol+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_260 /* AssetImageSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageSet.swift; sourceTree = "<group>"; };
+		OBJ_261 /* AssetImageSetContents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageSetContents.swift; sourceTree = "<group>"; };
+		OBJ_262 /* AssetImageSizeClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageSizeClass.swift; sourceTree = "<group>"; };
+		OBJ_263 /* AssetImageTemplateRenderingIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetImageTemplateRenderingIntent.swift; sourceTree = "<group>"; };
+		OBJ_265 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_266 /* CLI+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CLI+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_267 /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_268 /* Decodable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_269 /* DispatchQueue+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DispatchQueue+Extensions.swift"; sourceTree = "<group>"; };
 		OBJ_27 /* ImagesContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesContext.swift; sourceTree = "<group>"; };
-		OBJ_270 /* OperatingSystemVersion+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_271 /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_272 /* Path+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_273 /* ProcessInfo+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_274 /* Promise+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_275 /* RangeReplaceableCollection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RangeReplaceableCollection+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_276 /* Sequence+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_277 /* SingleValueDecodingContainer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SingleValueDecodingContainer+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_278 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_279 /* UnkeyedDecodingContainer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnkeyedDecodingContainer+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_270 /* Encodable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_271 /* FloatingPoint+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FloatingPoint+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_272 /* JSONDecoder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONDecoder+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_273 /* JSONEncoder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSONEncoder+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_274 /* KeyedDecodingContainerProtocol+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainerProtocol+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_275 /* OperatingSystemVersion+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_276 /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_277 /* Path+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Path+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_278 /* ProcessInfo+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProcessInfo+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_279 /* Promise+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+Extensions.swift"; sourceTree = "<group>"; };
 		OBJ_28 /* ImagesGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesGenerator.swift; sourceTree = "<group>"; };
-		OBJ_282 /* HTTPBodyEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBodyEncoder.swift; sourceTree = "<group>"; };
-		OBJ_283 /* HTTPBodyJSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBodyJSONEncoder.swift; sourceTree = "<group>"; };
-		OBJ_284 /* HTTPBodyURLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBodyURLEncoder.swift; sourceTree = "<group>"; };
-		OBJ_285 /* HTTPActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPActivityIndicator.swift; sourceTree = "<group>"; };
-		OBJ_286 /* HTTPAnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPAnyEncodable.swift; sourceTree = "<group>"; };
-		OBJ_287 /* HTTPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPError.swift; sourceTree = "<group>"; };
-		OBJ_288 /* HTTPErrorStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPErrorStringConvertible.swift; sourceTree = "<group>"; };
-		OBJ_289 /* HTTPHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeader.swift; sourceTree = "<group>"; };
-		OBJ_290 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
-		OBJ_291 /* HTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
-		OBJ_292 /* HTTPRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRoute.swift; sourceTree = "<group>"; };
-		OBJ_293 /* HTTPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPService.swift; sourceTree = "<group>"; };
-		OBJ_294 /* HTTPServiceTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPServiceTask.swift; sourceTree = "<group>"; };
-		OBJ_295 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
-		OBJ_296 /* HTTPTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTask.swift; sourceTree = "<group>"; };
-		OBJ_297 /* HTTPUIActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPUIActivityIndicator.swift; sourceTree = "<group>"; };
-		OBJ_299 /* HTTPQueryEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPQueryEncoder.swift; sourceTree = "<group>"; };
+		OBJ_280 /* RangeReplaceableCollection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RangeReplaceableCollection+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_281 /* Sequence+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Sequence+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_282 /* SingleValueDecodingContainer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SingleValueDecodingContainer+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_283 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_284 /* UnkeyedDecodingContainer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UnkeyedDecodingContainer+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_287 /* HTTPBodyEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBodyEncoder.swift; sourceTree = "<group>"; };
+		OBJ_288 /* HTTPBodyJSONEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBodyJSONEncoder.swift; sourceTree = "<group>"; };
+		OBJ_289 /* HTTPBodyURLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBodyURLEncoder.swift; sourceTree = "<group>"; };
+		OBJ_290 /* HTTPActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPActivityIndicator.swift; sourceTree = "<group>"; };
+		OBJ_291 /* HTTPAnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPAnyEncodable.swift; sourceTree = "<group>"; };
+		OBJ_292 /* HTTPError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPError.swift; sourceTree = "<group>"; };
+		OBJ_293 /* HTTPErrorStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPErrorStringConvertible.swift; sourceTree = "<group>"; };
+		OBJ_294 /* HTTPHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeader.swift; sourceTree = "<group>"; };
+		OBJ_295 /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
+		OBJ_296 /* HTTPResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponse.swift; sourceTree = "<group>"; };
+		OBJ_297 /* HTTPRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRoute.swift; sourceTree = "<group>"; };
+		OBJ_298 /* HTTPService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPService.swift; sourceTree = "<group>"; };
+		OBJ_299 /* HTTPServiceTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPServiceTask.swift; sourceTree = "<group>"; };
 		OBJ_30 /* DefaultLibraryGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLibraryGenerator.swift; sourceTree = "<group>"; };
-		OBJ_300 /* HTTPQueryURLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPQueryURLEncoder.swift; sourceTree = "<group>"; };
-		OBJ_302 /* HTTPDataResponseSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPDataResponseSerializer.swift; sourceTree = "<group>"; };
-		OBJ_303 /* HTTPDecodableResponseSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPDecodableResponseSerializer.swift; sourceTree = "<group>"; };
-		OBJ_304 /* HTTPEmptyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPEmptyResponse.swift; sourceTree = "<group>"; };
-		OBJ_305 /* HTTPJSONResponseSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPJSONResponseSerializer.swift; sourceTree = "<group>"; };
-		OBJ_306 /* HTTPResponseDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseDecoder.swift; sourceTree = "<group>"; };
-		OBJ_307 /* HTTPResponseSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseSerializer.swift; sourceTree = "<group>"; };
-		OBJ_308 /* HTTPStringResponseSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStringResponseSerializer.swift; sourceTree = "<group>"; };
+		OBJ_300 /* HTTPStatusCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStatusCode.swift; sourceTree = "<group>"; };
+		OBJ_301 /* HTTPTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTask.swift; sourceTree = "<group>"; };
+		OBJ_302 /* HTTPUIActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPUIActivityIndicator.swift; sourceTree = "<group>"; };
+		OBJ_304 /* HTTPQueryEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPQueryEncoder.swift; sourceTree = "<group>"; };
+		OBJ_305 /* HTTPQueryURLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPQueryURLEncoder.swift; sourceTree = "<group>"; };
+		OBJ_307 /* HTTPDataResponseSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPDataResponseSerializer.swift; sourceTree = "<group>"; };
+		OBJ_308 /* HTTPDecodableResponseSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPDecodableResponseSerializer.swift; sourceTree = "<group>"; };
+		OBJ_309 /* HTTPEmptyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPEmptyResponse.swift; sourceTree = "<group>"; };
 		OBJ_31 /* LibraryGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryGenerator.swift; sourceTree = "<group>"; };
-		OBJ_310 /* AnyCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
-		OBJ_311 /* AnyCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodingKey.swift; sourceTree = "<group>"; };
-		OBJ_312 /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
-		OBJ_313 /* MessageError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageError.swift; sourceTree = "<group>"; };
-		OBJ_315 /* URLArrayEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLArrayEncodingStrategy.swift; sourceTree = "<group>"; };
-		OBJ_316 /* URLBoolEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBoolEncodingStrategy.swift; sourceTree = "<group>"; };
-		OBJ_317 /* URLDateEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLDateEncodingStrategy.swift; sourceTree = "<group>"; };
-		OBJ_318 /* URLEncodedForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedForm.swift; sourceTree = "<group>"; };
-		OBJ_319 /* URLEncodedFormComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormComponent.swift; sourceTree = "<group>"; };
-		OBJ_320 /* URLEncodedFormContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormContext.swift; sourceTree = "<group>"; };
-		OBJ_321 /* URLEncodedFormEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormEncoder.swift; sourceTree = "<group>"; };
-		OBJ_322 /* URLEncodedFormKeyedEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormKeyedEncodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_323 /* URLEncodedFormSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormSerializer.swift; sourceTree = "<group>"; };
-		OBJ_324 /* URLEncodedFormSingleValueEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormSingleValueEncodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_325 /* URLEncodedFormUnkeyedEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormUnkeyedEncodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_326 /* URLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncoder.swift; sourceTree = "<group>"; };
-		OBJ_327 /* URLSpaceEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSpaceEncodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_310 /* HTTPJSONResponseSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPJSONResponseSerializer.swift; sourceTree = "<group>"; };
+		OBJ_311 /* HTTPResponseDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseDecoder.swift; sourceTree = "<group>"; };
+		OBJ_312 /* HTTPResponseSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPResponseSerializer.swift; sourceTree = "<group>"; };
+		OBJ_313 /* HTTPStringResponseSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStringResponseSerializer.swift; sourceTree = "<group>"; };
+		OBJ_315 /* AnyCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
+		OBJ_316 /* AnyCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodingKey.swift; sourceTree = "<group>"; };
+		OBJ_317 /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
+		OBJ_318 /* MessageError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageError.swift; sourceTree = "<group>"; };
+		OBJ_320 /* URLArrayEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLArrayEncodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_321 /* URLBoolEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLBoolEncodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_322 /* URLDateEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLDateEncodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_323 /* URLEncodedForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedForm.swift; sourceTree = "<group>"; };
+		OBJ_324 /* URLEncodedFormComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormComponent.swift; sourceTree = "<group>"; };
+		OBJ_325 /* URLEncodedFormContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormContext.swift; sourceTree = "<group>"; };
+		OBJ_326 /* URLEncodedFormEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormEncoder.swift; sourceTree = "<group>"; };
+		OBJ_327 /* URLEncodedFormKeyedEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormKeyedEncodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_328 /* URLEncodedFormSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormSerializer.swift; sourceTree = "<group>"; };
+		OBJ_329 /* URLEncodedFormSingleValueEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormSingleValueEncodingContainer.swift; sourceTree = "<group>"; };
 		OBJ_33 /* DefaultShadowStylesGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultShadowStylesGenerator.swift; sourceTree = "<group>"; };
-		OBJ_330 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		OBJ_331 /* FugenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FugenTests.swift; sourceTree = "<group>"; };
-		OBJ_332 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
-		OBJ_334 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		OBJ_335 /* FugenToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FugenToolsTests.swift; sourceTree = "<group>"; };
-		OBJ_336 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
-		OBJ_339 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/timursafigullin/Desktop/Swift/Fugen/.build/checkouts/DictionaryCoder/Package.swift; sourceTree = "<group>"; };
+		OBJ_330 /* URLEncodedFormUnkeyedEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncodedFormUnkeyedEncodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_331 /* URLEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLEncoder.swift; sourceTree = "<group>"; };
+		OBJ_332 /* URLSpaceEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSpaceEncodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_335 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		OBJ_336 /* FugenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FugenTests.swift; sourceTree = "<group>"; };
+		OBJ_337 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
+		OBJ_339 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		OBJ_34 /* ShadowStylesContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStylesContext.swift; sourceTree = "<group>"; };
-		OBJ_341 /* DictionaryComponentDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryComponentDecoder.swift; sourceTree = "<group>"; };
-		OBJ_342 /* DictionaryDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDecoder.swift; sourceTree = "<group>"; };
-		OBJ_343 /* DictionaryDecodingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDecodingOptions.swift; sourceTree = "<group>"; };
-		OBJ_344 /* DictionaryKeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryKeyedDecodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_345 /* DictionarySingleValueDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionarySingleValueDecodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_346 /* DictionaryUnkeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryUnkeyedDecodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_348 /* DictionaryDataDecodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDataDecodingStrategy.swift; sourceTree = "<group>"; };
-		OBJ_349 /* DictionaryDateDecodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDateDecodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_340 /* FugenToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FugenToolsTests.swift; sourceTree = "<group>"; };
+		OBJ_341 /* XCTestManifests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTestManifests.swift; sourceTree = "<group>"; };
+		OBJ_344 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/t.shafigullin/Desktop/Swift/Fugen/.build/checkouts/DictionaryCoder/Package.swift; sourceTree = "<group>"; };
+		OBJ_346 /* DictionaryComponentDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryComponentDecoder.swift; sourceTree = "<group>"; };
+		OBJ_347 /* DictionaryDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDecoder.swift; sourceTree = "<group>"; };
+		OBJ_348 /* DictionaryDecodingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDecodingOptions.swift; sourceTree = "<group>"; };
+		OBJ_349 /* DictionaryKeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryKeyedDecodingContainer.swift; sourceTree = "<group>"; };
 		OBJ_35 /* ShadowStylesGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStylesGenerator.swift; sourceTree = "<group>"; };
-		OBJ_350 /* DictionaryKeyDecodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryKeyDecodingStrategy.swift; sourceTree = "<group>"; };
-		OBJ_351 /* DictionaryNonConformingFloatDecodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryNonConformingFloatDecodingStrategy.swift; sourceTree = "<group>"; };
-		OBJ_353 /* DictionaryAnyKeyedEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryAnyKeyedEncodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_354 /* DictionaryComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryComponent.swift; sourceTree = "<group>"; };
-		OBJ_355 /* DictionaryComponentContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryComponentContainer.swift; sourceTree = "<group>"; };
-		OBJ_356 /* DictionaryComponentEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryComponentEncoder.swift; sourceTree = "<group>"; };
-		OBJ_357 /* DictionaryEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryEncoder.swift; sourceTree = "<group>"; };
-		OBJ_358 /* DictionaryEncodingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryEncodingOptions.swift; sourceTree = "<group>"; };
-		OBJ_359 /* DictionaryKeyedEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryKeyedEncodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_360 /* DictionarySingleValueEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionarySingleValueEncodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_361 /* DictionaryUnkeyedEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryUnkeyedEncodingContainer.swift; sourceTree = "<group>"; };
-		OBJ_363 /* DictionaryDataEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDataEncodingStrategy.swift; sourceTree = "<group>"; };
-		OBJ_364 /* DictionaryDateEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDateEncodingStrategy.swift; sourceTree = "<group>"; };
-		OBJ_365 /* DictionaryKeyEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryKeyEncodingStrategy.swift; sourceTree = "<group>"; };
-		OBJ_366 /* DictionaryNonConformingFloatEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryNonConformingFloatEncodingStrategy.swift; sourceTree = "<group>"; };
-		OBJ_368 /* AnyCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodingKey.swift; sourceTree = "<group>"; };
-		OBJ_369 /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_350 /* DictionarySingleValueDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionarySingleValueDecodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_351 /* DictionaryUnkeyedDecodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryUnkeyedDecodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_353 /* DictionaryDataDecodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDataDecodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_354 /* DictionaryDateDecodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDateDecodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_355 /* DictionaryKeyDecodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryKeyDecodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_356 /* DictionaryNonConformingFloatDecodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryNonConformingFloatDecodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_358 /* DictionaryAnyKeyedEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryAnyKeyedEncodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_359 /* DictionaryComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryComponent.swift; sourceTree = "<group>"; };
+		OBJ_360 /* DictionaryComponentContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryComponentContainer.swift; sourceTree = "<group>"; };
+		OBJ_361 /* DictionaryComponentEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryComponentEncoder.swift; sourceTree = "<group>"; };
+		OBJ_362 /* DictionaryEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryEncoder.swift; sourceTree = "<group>"; };
+		OBJ_363 /* DictionaryEncodingOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryEncodingOptions.swift; sourceTree = "<group>"; };
+		OBJ_364 /* DictionaryKeyedEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryKeyedEncodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_365 /* DictionarySingleValueEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionarySingleValueEncodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_366 /* DictionaryUnkeyedEncodingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryUnkeyedEncodingContainer.swift; sourceTree = "<group>"; };
+		OBJ_368 /* DictionaryDataEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDataEncodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_369 /* DictionaryDateEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDateEncodingStrategy.swift; sourceTree = "<group>"; };
 		OBJ_37 /* DefaultTextStylesGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTextStylesGenerator.swift; sourceTree = "<group>"; };
-		OBJ_370 /* RangeReplaceableCollection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RangeReplaceableCollection+Extensions.swift"; sourceTree = "<group>"; };
-		OBJ_372 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/timursafigullin/Desktop/Swift/Fugen/.build/checkouts/PromiseKit/Package.swift; sourceTree = "<group>"; };
-		OBJ_373 /* Box.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
-		OBJ_374 /* Catchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Catchable.swift; sourceTree = "<group>"; };
-		OBJ_375 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
-		OBJ_376 /* CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomStringConvertible.swift; sourceTree = "<group>"; };
-		OBJ_377 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
-		OBJ_378 /* Guarantee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Guarantee.swift; sourceTree = "<group>"; };
-		OBJ_379 /* LogEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEvent.swift; sourceTree = "<group>"; };
+		OBJ_370 /* DictionaryKeyEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryKeyEncodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_371 /* DictionaryNonConformingFloatEncodingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryNonConformingFloatEncodingStrategy.swift; sourceTree = "<group>"; };
+		OBJ_373 /* AnyCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodingKey.swift; sourceTree = "<group>"; };
+		OBJ_374 /* Optional+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_375 /* RangeReplaceableCollection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RangeReplaceableCollection+Extensions.swift"; sourceTree = "<group>"; };
+		OBJ_377 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/t.shafigullin/Desktop/Swift/Fugen/.build/checkouts/PromiseKit/Package.swift; sourceTree = "<group>"; };
+		OBJ_378 /* Box.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
+		OBJ_379 /* Catchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Catchable.swift; sourceTree = "<group>"; };
 		OBJ_38 /* TextStylesContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStylesContext.swift; sourceTree = "<group>"; };
-		OBJ_380 /* Promise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Promise.swift; sourceTree = "<group>"; };
-		OBJ_381 /* Resolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
-		OBJ_382 /* Thenable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thenable.swift; sourceTree = "<group>"; };
-		OBJ_383 /* after.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = after.swift; sourceTree = "<group>"; };
-		OBJ_384 /* firstly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = firstly.swift; sourceTree = "<group>"; };
-		OBJ_385 /* hang.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hang.swift; sourceTree = "<group>"; };
-		OBJ_386 /* race.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = race.swift; sourceTree = "<group>"; };
-		OBJ_387 /* when.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = when.swift; sourceTree = "<group>"; };
+		OBJ_380 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		OBJ_381 /* CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomStringConvertible.swift; sourceTree = "<group>"; };
+		OBJ_382 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
+		OBJ_383 /* Guarantee.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Guarantee.swift; sourceTree = "<group>"; };
+		OBJ_384 /* LogEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEvent.swift; sourceTree = "<group>"; };
+		OBJ_385 /* Promise.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Promise.swift; sourceTree = "<group>"; };
+		OBJ_386 /* Resolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
+		OBJ_387 /* Thenable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Thenable.swift; sourceTree = "<group>"; };
+		OBJ_388 /* after.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = after.swift; sourceTree = "<group>"; };
+		OBJ_389 /* firstly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = firstly.swift; sourceTree = "<group>"; };
 		OBJ_39 /* TextStylesGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStylesGenerator.swift; sourceTree = "<group>"; };
-		OBJ_390 /* CallMacroNodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallMacroNodes.swift; sourceTree = "<group>"; };
-		OBJ_391 /* Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
-		OBJ_392 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
-		OBJ_393 /* Filters+Numbers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Filters+Numbers.swift"; sourceTree = "<group>"; };
-		OBJ_394 /* Filters+Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Filters+Strings.swift"; sourceTree = "<group>"; };
-		OBJ_395 /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
-		OBJ_396 /* MapNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapNode.swift; sourceTree = "<group>"; };
-		OBJ_397 /* Parameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parameters.swift; sourceTree = "<group>"; };
-		OBJ_398 /* SetNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNode.swift; sourceTree = "<group>"; };
-		OBJ_399 /* StencilSwiftTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilSwiftTemplate.swift; sourceTree = "<group>"; };
-		OBJ_400 /* SwiftIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftIdentifier.swift; sourceTree = "<group>"; };
-		OBJ_401 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/timursafigullin/Desktop/Swift/Fugen/.build/checkouts/StencilSwiftKit/Package.swift; sourceTree = "<group>"; };
-		OBJ_403 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/timursafigullin/Desktop/Swift/Fugen/.build/checkouts/Stencil/Package.swift; sourceTree = "<group>"; };
-		OBJ_404 /* Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
-		OBJ_405 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
-		OBJ_406 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
-		OBJ_407 /* Expression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Expression.swift; sourceTree = "<group>"; };
-		OBJ_408 /* Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
-		OBJ_409 /* FilterTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTag.swift; sourceTree = "<group>"; };
+		OBJ_390 /* hang.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = hang.swift; sourceTree = "<group>"; };
+		OBJ_391 /* race.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = race.swift; sourceTree = "<group>"; };
+		OBJ_392 /* when.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = when.swift; sourceTree = "<group>"; };
+		OBJ_395 /* CallMacroNodes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CallMacroNodes.swift; sourceTree = "<group>"; };
+		OBJ_396 /* Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
+		OBJ_397 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		OBJ_398 /* Filters+Numbers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Filters+Numbers.swift"; sourceTree = "<group>"; };
+		OBJ_399 /* Filters+Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Filters+Strings.swift"; sourceTree = "<group>"; };
+		OBJ_400 /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
+		OBJ_401 /* MapNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapNode.swift; sourceTree = "<group>"; };
+		OBJ_402 /* Parameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parameters.swift; sourceTree = "<group>"; };
+		OBJ_403 /* SetNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNode.swift; sourceTree = "<group>"; };
+		OBJ_404 /* StencilSwiftTemplate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StencilSwiftTemplate.swift; sourceTree = "<group>"; };
+		OBJ_405 /* SwiftIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftIdentifier.swift; sourceTree = "<group>"; };
+		OBJ_406 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/t.shafigullin/Desktop/Swift/Fugen/.build/checkouts/StencilSwiftKit/Package.swift; sourceTree = "<group>"; };
+		OBJ_408 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/t.shafigullin/Desktop/Swift/Fugen/.build/checkouts/Stencil/Package.swift; sourceTree = "<group>"; };
+		OBJ_409 /* Context.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Context.swift; sourceTree = "<group>"; };
 		OBJ_41 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
-		OBJ_410 /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
-		OBJ_411 /* ForTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForTag.swift; sourceTree = "<group>"; };
-		OBJ_412 /* IfTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IfTag.swift; sourceTree = "<group>"; };
-		OBJ_413 /* Include.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Include.swift; sourceTree = "<group>"; };
-		OBJ_414 /* Inheritence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inheritence.swift; sourceTree = "<group>"; };
-		OBJ_415 /* KeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPath.swift; sourceTree = "<group>"; };
-		OBJ_416 /* Lexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lexer.swift; sourceTree = "<group>"; };
-		OBJ_417 /* Loader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
-		OBJ_418 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
-		OBJ_419 /* NowTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowTag.swift; sourceTree = "<group>"; };
-		OBJ_420 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
-		OBJ_421 /* Template.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Template.swift; sourceTree = "<group>"; };
-		OBJ_422 /* Tokenizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
-		OBJ_423 /* Variable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variable.swift; sourceTree = "<group>"; };
-		OBJ_425 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/timursafigullin/Desktop/Swift/Fugen/.build/checkouts/PathKit/Package.swift; sourceTree = "<group>"; };
-		OBJ_426 /* PathKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathKit.swift; sourceTree = "<group>"; };
+		OBJ_410 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		OBJ_411 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
+		OBJ_412 /* Expression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Expression.swift; sourceTree = "<group>"; };
+		OBJ_413 /* Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
+		OBJ_414 /* FilterTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterTag.swift; sourceTree = "<group>"; };
+		OBJ_415 /* Filters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Filters.swift; sourceTree = "<group>"; };
+		OBJ_416 /* ForTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForTag.swift; sourceTree = "<group>"; };
+		OBJ_417 /* IfTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IfTag.swift; sourceTree = "<group>"; };
+		OBJ_418 /* Include.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Include.swift; sourceTree = "<group>"; };
+		OBJ_419 /* Inheritence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Inheritence.swift; sourceTree = "<group>"; };
+		OBJ_420 /* KeyPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyPath.swift; sourceTree = "<group>"; };
+		OBJ_421 /* Lexer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lexer.swift; sourceTree = "<group>"; };
+		OBJ_422 /* Loader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loader.swift; sourceTree = "<group>"; };
+		OBJ_423 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		OBJ_424 /* NowTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowTag.swift; sourceTree = "<group>"; };
+		OBJ_425 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
+		OBJ_426 /* Template.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Template.swift; sourceTree = "<group>"; };
+		OBJ_427 /* Tokenizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tokenizer.swift; sourceTree = "<group>"; };
+		OBJ_428 /* Variable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variable.swift; sourceTree = "<group>"; };
 		OBJ_43 /* ColorStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStyle.swift; sourceTree = "<group>"; };
-		OBJ_430 /* api.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = api.c; sourceTree = "<group>"; };
-		OBJ_431 /* emitter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = emitter.c; sourceTree = "<group>"; };
-		OBJ_432 /* parser.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = parser.c; sourceTree = "<group>"; };
-		OBJ_433 /* reader.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = reader.c; sourceTree = "<group>"; };
-		OBJ_434 /* scanner.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = scanner.c; sourceTree = "<group>"; };
-		OBJ_435 /* writer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = writer.c; sourceTree = "<group>"; };
-		OBJ_437 /* CYaml.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CYaml.h; sourceTree = "<group>"; };
-		OBJ_438 /* yaml.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = yaml.h; sourceTree = "<group>"; };
+		OBJ_430 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/t.shafigullin/Desktop/Swift/Fugen/.build/checkouts/PathKit/Package.swift; sourceTree = "<group>"; };
+		OBJ_431 /* PathKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathKit.swift; sourceTree = "<group>"; };
+		OBJ_435 /* api.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = api.c; sourceTree = "<group>"; };
+		OBJ_436 /* emitter.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = emitter.c; sourceTree = "<group>"; };
+		OBJ_437 /* parser.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = parser.c; sourceTree = "<group>"; };
+		OBJ_438 /* reader.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = reader.c; sourceTree = "<group>"; };
+		OBJ_439 /* scanner.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = scanner.c; sourceTree = "<group>"; };
 		OBJ_44 /* ColorStyleAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStyleAsset.swift; sourceTree = "<group>"; };
-		OBJ_440 /* Constructor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constructor.swift; sourceTree = "<group>"; };
-		OBJ_441 /* Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
-		OBJ_442 /* Emitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Emitter.swift; sourceTree = "<group>"; };
-		OBJ_443 /* Encoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encoder.swift; sourceTree = "<group>"; };
-		OBJ_444 /* Mark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mark.swift; sourceTree = "<group>"; };
-		OBJ_445 /* Node.Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.Mapping.swift; sourceTree = "<group>"; };
-		OBJ_446 /* Node.Scalar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.Scalar.swift; sourceTree = "<group>"; };
-		OBJ_447 /* Node.Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.Sequence.swift; sourceTree = "<group>"; };
-		OBJ_448 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
-		OBJ_449 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
+		OBJ_440 /* writer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = writer.c; sourceTree = "<group>"; };
+		OBJ_442 /* CYaml.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CYaml.h; sourceTree = "<group>"; };
+		OBJ_443 /* yaml.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = yaml.h; sourceTree = "<group>"; };
+		OBJ_445 /* Constructor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constructor.swift; sourceTree = "<group>"; };
+		OBJ_446 /* Decoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Decoder.swift; sourceTree = "<group>"; };
+		OBJ_447 /* Emitter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Emitter.swift; sourceTree = "<group>"; };
+		OBJ_448 /* Encoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Encoder.swift; sourceTree = "<group>"; };
+		OBJ_449 /* Mark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mark.swift; sourceTree = "<group>"; };
 		OBJ_45 /* ColorStyleNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStyleNode.swift; sourceTree = "<group>"; };
-		OBJ_450 /* Representer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Representer.swift; sourceTree = "<group>"; };
-		OBJ_451 /* Resolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
-		OBJ_452 /* String+Yams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Yams.swift"; sourceTree = "<group>"; };
-		OBJ_453 /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
-		OBJ_454 /* YamlError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamlError.swift; sourceTree = "<group>"; };
-		OBJ_455 /* shim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = shim.swift; sourceTree = "<group>"; };
-		OBJ_456 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/timursafigullin/Desktop/Swift/Fugen/.build/checkouts/Yams/Package.swift; sourceTree = "<group>"; };
-		OBJ_458 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/timursafigullin/Desktop/Swift/Fugen/.build/checkouts/Rainbow/Package.swift; sourceTree = "<group>"; };
-		OBJ_459 /* BackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundColor.swift; sourceTree = "<group>"; };
-		OBJ_460 /* CodesParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodesParser.swift; sourceTree = "<group>"; };
-		OBJ_461 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
-		OBJ_462 /* ControlCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCode.swift; sourceTree = "<group>"; };
-		OBJ_463 /* ModesExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModesExtractor.swift; sourceTree = "<group>"; };
-		OBJ_464 /* OutputTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputTarget.swift; sourceTree = "<group>"; };
-		OBJ_465 /* Rainbow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rainbow.swift; sourceTree = "<group>"; };
-		OBJ_466 /* String+Rainbow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Rainbow.swift"; sourceTree = "<group>"; };
-		OBJ_467 /* StringGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringGenerator.swift; sourceTree = "<group>"; };
-		OBJ_468 /* Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
-		OBJ_469 /* XcodeColorsSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeColorsSupport.swift; sourceTree = "<group>"; };
+		OBJ_450 /* Node.Mapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.Mapping.swift; sourceTree = "<group>"; };
+		OBJ_451 /* Node.Scalar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.Scalar.swift; sourceTree = "<group>"; };
+		OBJ_452 /* Node.Sequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.Sequence.swift; sourceTree = "<group>"; };
+		OBJ_453 /* Node.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Node.swift; sourceTree = "<group>"; };
+		OBJ_454 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
+		OBJ_455 /* Representer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Representer.swift; sourceTree = "<group>"; };
+		OBJ_456 /* Resolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Resolver.swift; sourceTree = "<group>"; };
+		OBJ_457 /* String+Yams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Yams.swift"; sourceTree = "<group>"; };
+		OBJ_458 /* Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tag.swift; sourceTree = "<group>"; };
+		OBJ_459 /* YamlError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YamlError.swift; sourceTree = "<group>"; };
+		OBJ_460 /* shim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = shim.swift; sourceTree = "<group>"; };
+		OBJ_461 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/t.shafigullin/Desktop/Swift/Fugen/.build/checkouts/Yams/Package.swift; sourceTree = "<group>"; };
+		OBJ_463 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/t.shafigullin/Desktop/Swift/Fugen/.build/checkouts/Rainbow/Package.swift; sourceTree = "<group>"; };
+		OBJ_464 /* BackgroundColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundColor.swift; sourceTree = "<group>"; };
+		OBJ_465 /* CodesParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodesParser.swift; sourceTree = "<group>"; };
+		OBJ_466 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
+		OBJ_467 /* ControlCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlCode.swift; sourceTree = "<group>"; };
+		OBJ_468 /* ModesExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModesExtractor.swift; sourceTree = "<group>"; };
+		OBJ_469 /* OutputTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputTarget.swift; sourceTree = "<group>"; };
 		OBJ_47 /* AccessTokenConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenConfiguration.swift; sourceTree = "<group>"; };
-		OBJ_472 /* ArgumentList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgumentList.swift; sourceTree = "<group>"; };
-		OBJ_473 /* ArgumentListManipulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgumentListManipulator.swift; sourceTree = "<group>"; };
-		OBJ_474 /* CLI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLI.swift; sourceTree = "<group>"; };
-		OBJ_475 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
-		OBJ_476 /* Compatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Compatibility.swift; sourceTree = "<group>"; };
-		OBJ_477 /* CompletionGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionGenerator.swift; sourceTree = "<group>"; };
-		OBJ_478 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
-		OBJ_479 /* HelpCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpCommand.swift; sourceTree = "<group>"; };
+		OBJ_470 /* Rainbow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rainbow.swift; sourceTree = "<group>"; };
+		OBJ_471 /* String+Rainbow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Rainbow.swift"; sourceTree = "<group>"; };
+		OBJ_472 /* StringGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringGenerator.swift; sourceTree = "<group>"; };
+		OBJ_473 /* Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
+		OBJ_474 /* XcodeColorsSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeColorsSupport.swift; sourceTree = "<group>"; };
+		OBJ_477 /* ArgumentList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgumentList.swift; sourceTree = "<group>"; };
+		OBJ_478 /* ArgumentListManipulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArgumentListManipulator.swift; sourceTree = "<group>"; };
+		OBJ_479 /* CLI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLI.swift; sourceTree = "<group>"; };
 		OBJ_48 /* BaseConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseConfiguration.swift; sourceTree = "<group>"; };
-		OBJ_480 /* HelpMessageGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpMessageGenerator.swift; sourceTree = "<group>"; };
-		OBJ_481 /* Input.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Input.swift; sourceTree = "<group>"; };
-		OBJ_482 /* Option.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Option.swift; sourceTree = "<group>"; };
-		OBJ_483 /* OptionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionGroup.swift; sourceTree = "<group>"; };
-		OBJ_484 /* OptionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionRegistry.swift; sourceTree = "<group>"; };
-		OBJ_485 /* Parameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parameter.swift; sourceTree = "<group>"; };
-		OBJ_486 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
-		OBJ_487 /* Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Path.swift; sourceTree = "<group>"; };
-		OBJ_488 /* Stream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream.swift; sourceTree = "<group>"; };
-		OBJ_489 /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
+		OBJ_480 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
+		OBJ_481 /* Compatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Compatibility.swift; sourceTree = "<group>"; };
+		OBJ_482 /* CompletionGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionGenerator.swift; sourceTree = "<group>"; };
+		OBJ_483 /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
+		OBJ_484 /* HelpCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpCommand.swift; sourceTree = "<group>"; };
+		OBJ_485 /* HelpMessageGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpMessageGenerator.swift; sourceTree = "<group>"; };
+		OBJ_486 /* Input.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Input.swift; sourceTree = "<group>"; };
+		OBJ_487 /* Option.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Option.swift; sourceTree = "<group>"; };
+		OBJ_488 /* OptionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionGroup.swift; sourceTree = "<group>"; };
+		OBJ_489 /* OptionRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionRegistry.swift; sourceTree = "<group>"; };
 		OBJ_49 /* ColorStylesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStylesConfiguration.swift; sourceTree = "<group>"; };
-		OBJ_490 /* Term.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Term.swift; sourceTree = "<group>"; };
-		OBJ_491 /* Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Validation.swift; sourceTree = "<group>"; };
-		OBJ_492 /* ValueBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueBox.swift; sourceTree = "<group>"; };
-		OBJ_493 /* VersionCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionCommand.swift; sourceTree = "<group>"; };
-		OBJ_494 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/timursafigullin/Desktop/Swift/Fugen/.build/checkouts/SwiftCLI/Package.swift; sourceTree = "<group>"; };
+		OBJ_490 /* Parameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parameter.swift; sourceTree = "<group>"; };
+		OBJ_491 /* Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
+		OBJ_492 /* Path.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Path.swift; sourceTree = "<group>"; };
+		OBJ_493 /* Stream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream.swift; sourceTree = "<group>"; };
+		OBJ_494 /* Task.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Task.swift; sourceTree = "<group>"; };
+		OBJ_495 /* Term.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Term.swift; sourceTree = "<group>"; };
+		OBJ_496 /* Validation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Validation.swift; sourceTree = "<group>"; };
+		OBJ_497 /* ValueBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValueBox.swift; sourceTree = "<group>"; };
+		OBJ_498 /* VersionCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionCommand.swift; sourceTree = "<group>"; };
+		OBJ_499 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = Package.swift; path = /Users/t.shafigullin/Desktop/Swift/Fugen/.build/checkouts/SwiftCLI/Package.swift; sourceTree = "<group>"; };
 		OBJ_50 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
-		OBJ_509 /* Demo */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Demo; sourceTree = SOURCE_ROOT; };
 		OBJ_51 /* FileConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileConfiguration.swift; sourceTree = "<group>"; };
-		OBJ_510 /* Docs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Docs; sourceTree = SOURCE_ROOT; };
-		OBJ_511 /* Scripts */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Scripts; sourceTree = SOURCE_ROOT; };
-		OBJ_512 /* Templates */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Templates; sourceTree = SOURCE_ROOT; };
-		OBJ_513 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
-		OBJ_514 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		OBJ_515 /* Package.resources */ = {isa = PBXFileReference; lastKnownFileType = text; path = Package.resources; sourceTree = "<group>"; };
-		OBJ_516 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		OBJ_517 /* Dangerfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Dangerfile; sourceTree = "<group>"; };
-		OBJ_518 /* Gemfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile; sourceTree = "<group>"; };
+		OBJ_514 /* Demo */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Demo; sourceTree = SOURCE_ROOT; };
+		OBJ_515 /* Docs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Docs; sourceTree = SOURCE_ROOT; };
+		OBJ_516 /* Scripts */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Scripts; sourceTree = SOURCE_ROOT; };
+		OBJ_517 /* Templates */ = {isa = PBXFileReference; lastKnownFileType = folder; path = Templates; sourceTree = SOURCE_ROOT; };
+		OBJ_518 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
+		OBJ_519 /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
 		OBJ_52 /* GenerationConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerationConfiguration.swift; sourceTree = "<group>"; };
-		OBJ_520 /* Brewfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Brewfile; sourceTree = "<group>"; };
-		OBJ_521 /* Fugen.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Fugen.podspec; sourceTree = "<group>"; };
+		OBJ_520 /* Package.resources */ = {isa = PBXFileReference; lastKnownFileType = text; path = Package.resources; sourceTree = "<group>"; };
+		OBJ_521 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		OBJ_522 /* Dangerfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Dangerfile; sourceTree = "<group>"; };
+		OBJ_523 /* Gemfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile; sourceTree = "<group>"; };
+		OBJ_524 /* Gemfile.lock */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile.lock; sourceTree = "<group>"; };
+		OBJ_525 /* Brewfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Brewfile; sourceTree = "<group>"; };
+		OBJ_526 /* Fugen.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Fugen.podspec; sourceTree = "<group>"; };
 		OBJ_53 /* ImagesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesConfiguration.swift; sourceTree = "<group>"; };
 		OBJ_54 /* ShadowStylesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStylesConfiguration.swift; sourceTree = "<group>"; };
 		OBJ_55 /* TextStylesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStylesConfiguration.swift; sourceTree = "<group>"; };
@@ -1155,151 +1158,152 @@
 		OBJ_68 /* ImagesParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesParameters.swift; sourceTree = "<group>"; };
 		OBJ_69 /* NodesParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodesParameters.swift; sourceTree = "<group>"; };
 		OBJ_70 /* RenderParameters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderParameters.swift; sourceTree = "<group>"; };
-		OBJ_72 /* ShadowStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStyle.swift; sourceTree = "<group>"; };
-		OBJ_73 /* ShadowStyleNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStyleNode.swift; sourceTree = "<group>"; };
-		OBJ_76 /* TextStyleColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleColor.swift; sourceTree = "<group>"; };
-		OBJ_77 /* TextStyleNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleNode.swift; sourceTree = "<group>"; };
-		OBJ_78 /* Vector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Vector.swift; sourceTree = "<group>"; };
-		OBJ_81 /* AssetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsProvider.swift; sourceTree = "<group>"; };
-		OBJ_82 /* DefaultAssetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAssetsProvider.swift; sourceTree = "<group>"; };
-		OBJ_85 /* ColorStyleAssetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStyleAssetsProvider.swift; sourceTree = "<group>"; };
-		OBJ_86 /* DefaultColorStyleAssetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultColorStyleAssetsProvider.swift; sourceTree = "<group>"; };
-		OBJ_87 /* ColorStylesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStylesProvider.swift; sourceTree = "<group>"; };
-		OBJ_88 /* ColorStylesProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStylesProviderError.swift; sourceTree = "<group>"; };
-		OBJ_89 /* DefaultColorStylesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultColorStylesProvider.swift; sourceTree = "<group>"; };
-		OBJ_91 /* ConfigurationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationProvider.swift; sourceTree = "<group>"; };
-		OBJ_92 /* DefaultConfigurationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultConfigurationProvider.swift; sourceTree = "<group>"; };
-		OBJ_94 /* DataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProvider.swift; sourceTree = "<group>"; };
-		OBJ_95 /* DefaultDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDataProvider.swift; sourceTree = "<group>"; };
-		OBJ_98 /* FigmaError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaError.swift; sourceTree = "<group>"; };
-		OBJ_99 /* FigmaImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FigmaImages.swift; sourceTree = "<group>"; };
+		OBJ_72 /* Shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Shadow.swift; sourceTree = "<group>"; };
+		OBJ_73 /* ShadowStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStyle.swift; sourceTree = "<group>"; };
+		OBJ_74 /* ShadowStyleNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowStyleNode.swift; sourceTree = "<group>"; };
+		OBJ_75 /* ShadowType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShadowType.swift; sourceTree = "<group>"; };
+		OBJ_77 /* TextStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyle.swift; sourceTree = "<group>"; };
+		OBJ_78 /* TextStyleColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleColor.swift; sourceTree = "<group>"; };
+		OBJ_79 /* TextStyleNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextStyleNode.swift; sourceTree = "<group>"; };
+		OBJ_80 /* Vector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Vector.swift; sourceTree = "<group>"; };
+		OBJ_83 /* AssetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssetsProvider.swift; sourceTree = "<group>"; };
+		OBJ_84 /* DefaultAssetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAssetsProvider.swift; sourceTree = "<group>"; };
+		OBJ_87 /* ColorStyleAssetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStyleAssetsProvider.swift; sourceTree = "<group>"; };
+		OBJ_88 /* DefaultColorStyleAssetsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultColorStyleAssetsProvider.swift; sourceTree = "<group>"; };
+		OBJ_89 /* ColorStylesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStylesProvider.swift; sourceTree = "<group>"; };
+		OBJ_90 /* ColorStylesProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorStylesProviderError.swift; sourceTree = "<group>"; };
+		OBJ_91 /* DefaultColorStylesProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultColorStylesProvider.swift; sourceTree = "<group>"; };
+		OBJ_93 /* ConfigurationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurationProvider.swift; sourceTree = "<group>"; };
+		OBJ_94 /* DefaultConfigurationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultConfigurationProvider.swift; sourceTree = "<group>"; };
+		OBJ_96 /* DataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProvider.swift; sourceTree = "<group>"; };
+		OBJ_97 /* DefaultDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDataProvider.swift; sourceTree = "<group>"; };
 		"PathKit::PathKit::Product" /* PathKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PathKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"PromiseKit::PromiseKit::Product" /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PromiseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Rainbow::Rainbow::Product" /* Rainbow.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Rainbow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Stencil::Stencil::Product" /* Stencil.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Stencil.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"StencilSwiftKit::StencilSwiftKit::Product" /* StencilSwiftKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = StencilSwiftKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"SwiftCLI::SwiftCLI::Product" /* SwiftCLI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftCLI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"Yams::CYaml::Product" /* CYaml.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CYaml.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"Yams::CYaml::Product" /* CYaml.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CYaml.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Yams::Yams::Product" /* Yams.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Yams.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		OBJ_1030 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_1031 /* PathKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_1054 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_1055 /* Stencil.framework in Frameworks */,
-				OBJ_1056 /* PathKit.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_1091 /* Frameworks */ = {
+		OBJ_1008 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_1118 /* Frameworks */ = {
+		OBJ_1039 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_1119 /* CYaml.framework in Frameworks */,
+				OBJ_1040 /* PathKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_536 /* Frameworks */ = {
+		OBJ_1063 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
+				OBJ_1064 /* Stencil.framework in Frameworks */,
+				OBJ_1065 /* PathKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_568 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_754 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_755 /* DictionaryCoder.framework in Frameworks */,
-				OBJ_756 /* StencilSwiftKit.framework in Frameworks */,
-				OBJ_757 /* Stencil.framework in Frameworks */,
-				OBJ_758 /* Rainbow.framework in Frameworks */,
-				OBJ_759 /* Yams.framework in Frameworks */,
-				OBJ_760 /* CYaml.framework in Frameworks */,
-				OBJ_761 /* FugenTools.framework in Frameworks */,
-				OBJ_762 /* PromiseKit.framework in Frameworks */,
-				OBJ_763 /* PathKit.framework in Frameworks */,
-				OBJ_764 /* SwiftCLI.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_803 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_804 /* DictionaryCoder.framework in Frameworks */,
-				OBJ_805 /* StencilSwiftKit.framework in Frameworks */,
-				OBJ_806 /* Stencil.framework in Frameworks */,
-				OBJ_807 /* Rainbow.framework in Frameworks */,
-				OBJ_808 /* Yams.framework in Frameworks */,
-				OBJ_809 /* CYaml.framework in Frameworks */,
-				OBJ_810 /* FugenTools.framework in Frameworks */,
-				OBJ_811 /* PromiseKit.framework in Frameworks */,
-				OBJ_812 /* PathKit.framework in Frameworks */,
-				OBJ_813 /* SwiftCLI.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_924 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_925 /* PromiseKit.framework in Frameworks */,
-				OBJ_926 /* PathKit.framework in Frameworks */,
-				OBJ_927 /* SwiftCLI.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_937 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 0;
-			files = (
-				OBJ_938 /* FugenTools.framework in Frameworks */,
-				OBJ_939 /* PromiseKit.framework in Frameworks */,
-				OBJ_940 /* PathKit.framework in Frameworks */,
-				OBJ_941 /* SwiftCLI.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		OBJ_951 /* Frameworks */ = {
+		OBJ_1100 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_977 /* Frameworks */ = {
+		OBJ_1127 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_1128 /* CYaml.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_541 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_999 /* Frameworks */ = {
+		OBJ_573 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_763 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_764 /* DictionaryCoder.framework in Frameworks */,
+				OBJ_765 /* StencilSwiftKit.framework in Frameworks */,
+				OBJ_766 /* Stencil.framework in Frameworks */,
+				OBJ_767 /* Rainbow.framework in Frameworks */,
+				OBJ_768 /* Yams.framework in Frameworks */,
+				OBJ_769 /* CYaml.framework in Frameworks */,
+				OBJ_770 /* FugenTools.framework in Frameworks */,
+				OBJ_771 /* PromiseKit.framework in Frameworks */,
+				OBJ_772 /* PathKit.framework in Frameworks */,
+				OBJ_773 /* SwiftCLI.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_812 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_813 /* DictionaryCoder.framework in Frameworks */,
+				OBJ_814 /* StencilSwiftKit.framework in Frameworks */,
+				OBJ_815 /* Stencil.framework in Frameworks */,
+				OBJ_816 /* Rainbow.framework in Frameworks */,
+				OBJ_817 /* Yams.framework in Frameworks */,
+				OBJ_818 /* CYaml.framework in Frameworks */,
+				OBJ_819 /* FugenTools.framework in Frameworks */,
+				OBJ_820 /* PromiseKit.framework in Frameworks */,
+				OBJ_821 /* PathKit.framework in Frameworks */,
+				OBJ_822 /* SwiftCLI.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_933 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_934 /* PromiseKit.framework in Frameworks */,
+				OBJ_935 /* PathKit.framework in Frameworks */,
+				OBJ_936 /* SwiftCLI.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_946 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+				OBJ_947 /* FugenTools.framework in Frameworks */,
+				OBJ_948 /* PromiseKit.framework in Frameworks */,
+				OBJ_949 /* PathKit.framework in Frameworks */,
+				OBJ_950 /* SwiftCLI.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_960 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		OBJ_986 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
@@ -1309,178 +1313,169 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		C0BE783A24E9B258004EBBEF /* Vector */ = {
+		OBJ_102 /* File */ = {
 			isa = PBXGroup;
 			children = (
-				C0BE783B24E9B26E004EBBEF /* StencilVectorFilter.swift */,
-				C0BE783D24E9B2E8004EBBEF /* StencilVectorInfoFilter.swift */,
-			);
-			path = Vector;
-			sourceTree = "<group>";
-		};
-		OBJ_100 /* File */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_136 /* Nodes */,
-				OBJ_101 /* FigmaBlendMode.swift */,
-				OBJ_102 /* FigmaBooleanOperationType.swift */,
-				OBJ_103 /* FigmaColor.swift */,
-				OBJ_104 /* FigmaColorStop.swift */,
-				OBJ_105 /* FigmaComponent.swift */,
-				OBJ_106 /* FigmaConstraint.swift */,
-				OBJ_107 /* FigmaConstraintType.swift */,
-				OBJ_108 /* FigmaEasingType.swift */,
-				OBJ_109 /* FigmaEffect.swift */,
-				OBJ_110 /* FigmaEffectType.swift */,
-				OBJ_111 /* FigmaExportSetting.swift */,
-				OBJ_112 /* FigmaFrameOffset.swift */,
-				OBJ_113 /* FigmaImageFormat.swift */,
-				OBJ_114 /* FigmaLayoutConstraint.swift */,
-				OBJ_115 /* FigmaLayoutGrid.swift */,
-				OBJ_116 /* FigmaLayoutGridAlignment.swift */,
-				OBJ_117 /* FigmaLayoutGridPattern.swift */,
-				OBJ_118 /* FigmaLayoutHorizontalConstraint.swift */,
-				OBJ_119 /* FigmaLayoutVerticalConstraint.swift */,
-				OBJ_120 /* FigmaLineHeightUnit.swift */,
-				OBJ_121 /* FigmaPaint.swift */,
-				OBJ_122 /* FigmaPaintType.swift */,
-				OBJ_123 /* FigmaRectangle.swift */,
-				OBJ_124 /* FigmaScaleMode.swift */,
-				OBJ_125 /* FigmaStrokeAlignment.swift */,
-				OBJ_126 /* FigmaStrokeCap.swift */,
-				OBJ_127 /* FigmaStrokeJoin.swift */,
-				OBJ_128 /* FigmaStyle.swift */,
-				OBJ_129 /* FigmaStyleType.swift */,
-				OBJ_130 /* FigmaTextCase.swift */,
-				OBJ_131 /* FigmaTextDecoration.swift */,
-				OBJ_132 /* FigmaTextHorizontalAlignment.swift */,
-				OBJ_133 /* FigmaTextVerticalAlignment.swift */,
-				OBJ_134 /* FigmaTypeStyle.swift */,
-				OBJ_135 /* FigmaVector.swift */,
+				OBJ_103 /* FigmaBlendMode.swift */,
+				OBJ_104 /* FigmaBooleanOperationType.swift */,
+				OBJ_105 /* FigmaColor.swift */,
+				OBJ_106 /* FigmaColorStop.swift */,
+				OBJ_107 /* FigmaComponent.swift */,
+				OBJ_108 /* FigmaConstraint.swift */,
+				OBJ_109 /* FigmaConstraintType.swift */,
+				OBJ_110 /* FigmaEasingType.swift */,
+				OBJ_111 /* FigmaEffect.swift */,
+				OBJ_112 /* FigmaEffectType.swift */,
+				OBJ_113 /* FigmaExportSetting.swift */,
+				OBJ_114 /* FigmaFrameOffset.swift */,
+				OBJ_115 /* FigmaImageFormat.swift */,
+				OBJ_116 /* FigmaLayoutConstraint.swift */,
+				OBJ_117 /* FigmaLayoutGrid.swift */,
+				OBJ_118 /* FigmaLayoutGridAlignment.swift */,
+				OBJ_119 /* FigmaLayoutGridPattern.swift */,
+				OBJ_120 /* FigmaLayoutHorizontalConstraint.swift */,
+				OBJ_121 /* FigmaLayoutVerticalConstraint.swift */,
+				OBJ_122 /* FigmaLineHeightUnit.swift */,
+				OBJ_123 /* FigmaPaint.swift */,
+				OBJ_124 /* FigmaPaintType.swift */,
+				OBJ_125 /* FigmaRectangle.swift */,
+				OBJ_126 /* FigmaScaleMode.swift */,
+				OBJ_127 /* FigmaStrokeAlignment.swift */,
+				OBJ_128 /* FigmaStrokeCap.swift */,
+				OBJ_129 /* FigmaStrokeJoin.swift */,
+				OBJ_130 /* FigmaStyle.swift */,
+				OBJ_131 /* FigmaStyleType.swift */,
+				OBJ_132 /* FigmaTextCase.swift */,
+				OBJ_133 /* FigmaTextDecoration.swift */,
+				OBJ_134 /* FigmaTextHorizontalAlignment.swift */,
+				OBJ_135 /* FigmaTextVerticalAlignment.swift */,
+				OBJ_136 /* FigmaTypeStyle.swift */,
+				OBJ_137 /* FigmaVector.swift */,
+				OBJ_138 /* Nodes */,
 			);
 			path = File;
 			sourceTree = "<group>";
 		};
-		OBJ_136 /* Nodes */ = {
+		OBJ_138 /* Nodes */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_137 /* FigmaBooleanOperationNodePayload.swift */,
-				OBJ_138 /* FigmaCanvasNodeInfo.swift */,
-				OBJ_139 /* FigmaDocumentNodeInfo.swift */,
-				OBJ_140 /* FigmaFile.swift */,
-				OBJ_141 /* FigmaFrameNodeInfo.swift */,
-				OBJ_142 /* FigmaInstanceNodePayload.swift */,
-				OBJ_143 /* FigmaNode.swift */,
-				OBJ_144 /* FigmaNodeType.swift */,
-				OBJ_145 /* FigmaRectangleNodePayload.swift */,
-				OBJ_146 /* FigmaSliceNodeInfo.swift */,
-				OBJ_147 /* FigmaTextNodePayload.swift */,
-				OBJ_148 /* FigmaVectorNodeInfo.swift */,
+				OBJ_139 /* FigmaBooleanOperationNodePayload.swift */,
+				OBJ_140 /* FigmaCanvasNodeInfo.swift */,
+				OBJ_141 /* FigmaDocumentNodeInfo.swift */,
+				OBJ_142 /* FigmaFile.swift */,
+				OBJ_143 /* FigmaFrameNodeInfo.swift */,
+				OBJ_144 /* FigmaInstanceNodePayload.swift */,
+				OBJ_145 /* FigmaNode.swift */,
+				OBJ_146 /* FigmaNodeType.swift */,
+				OBJ_147 /* FigmaRectangleNodePayload.swift */,
+				OBJ_148 /* FigmaSliceNodeInfo.swift */,
+				OBJ_149 /* FigmaTextNodePayload.swift */,
+				OBJ_150 /* FigmaVectorNodeInfo.swift */,
 			);
 			path = Nodes;
 			sourceTree = "<group>";
 		};
-		OBJ_156 /* Routes */ = {
+		OBJ_158 /* Routes */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_157 /* FigmaAPIFileRoute.swift */,
-				OBJ_158 /* FigmaAPIFileRouteQueryParameters.swift */,
-				OBJ_159 /* FigmaAPIImagesRoute.swift */,
-				OBJ_160 /* FigmaAPIImagesRouteQueryParameters.swift */,
+				OBJ_159 /* FigmaAPIFileRoute.swift */,
+				OBJ_160 /* FigmaAPIFileRouteQueryParameters.swift */,
+				OBJ_161 /* FigmaAPIImagesRoute.swift */,
+				OBJ_162 /* FigmaAPIImagesRouteQueryParameters.swift */,
 			);
 			path = Routes;
 			sourceTree = "<group>";
 		};
-		OBJ_161 /* FigmaFiles */ = {
+		OBJ_163 /* FigmaFiles */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_162 /* DefaultFigmaFilesProvider.swift */,
-				OBJ_163 /* FigmaFilesProvider.swift */,
+				OBJ_164 /* DefaultFigmaFilesProvider.swift */,
+				OBJ_165 /* FigmaFilesProvider.swift */,
 			);
 			path = FigmaFiles;
 			sourceTree = "<group>";
 		};
-		OBJ_164 /* FigmaNodes */ = {
+		OBJ_166 /* FigmaNodes */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_165 /* DefaultFigmaNodesProvider.swift */,
-				OBJ_166 /* FigmaNodesProvider.swift */,
-				OBJ_167 /* FigmaNodesProviderError.swift */,
+				OBJ_167 /* DefaultFigmaNodesProvider.swift */,
+				OBJ_168 /* FigmaNodesProvider.swift */,
+				OBJ_169 /* FigmaNodesProviderError.swift */,
 			);
 			path = FigmaNodes;
 			sourceTree = "<group>";
 		};
-		OBJ_168 /* Images */ = {
+		OBJ_170 /* Images */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_169 /* Assets */,
-				OBJ_175 /* Render */,
-				OBJ_179 /* Resources */,
-				OBJ_172 /* DefaultImagesProvider.swift */,
-				OBJ_173 /* ImagesProvider.swift */,
-				OBJ_174 /* ImagesProviderError.swift */,
+				OBJ_171 /* Assets */,
+				OBJ_174 /* DefaultImagesProvider.swift */,
+				OBJ_175 /* ImagesProvider.swift */,
+				OBJ_176 /* ImagesProviderError.swift */,
+				OBJ_177 /* Render */,
+				OBJ_181 /* Resources */,
 			);
 			path = Images;
 			sourceTree = "<group>";
 		};
-		OBJ_169 /* Assets */ = {
+		OBJ_171 /* Assets */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_170 /* DefaultImageAssetsProvider.swift */,
-				OBJ_171 /* ImageAssetsProvider.swift */,
+				OBJ_172 /* DefaultImageAssetsProvider.swift */,
+				OBJ_173 /* ImageAssetsProvider.swift */,
 			);
 			path = Assets;
 			sourceTree = "<group>";
 		};
-		OBJ_175 /* Render */ = {
+		OBJ_177 /* Render */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_176 /* DefaultImageRenderProvider.swift */,
-				OBJ_177 /* ImageRenderProvider.swift */,
-				OBJ_178 /* ImageRenderProviderError.swift */,
+				OBJ_178 /* DefaultImageRenderProvider.swift */,
+				OBJ_179 /* ImageRenderProvider.swift */,
+				OBJ_180 /* ImageRenderProviderError.swift */,
 			);
 			path = Render;
-			sourceTree = "<group>";
-		};
-		OBJ_179 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_180 /* DefaultImageResourcesProvider.swift */,
-				OBJ_181 /* ImageResourcesProvider.swift */,
-			);
-			path = Resources;
 			sourceTree = "<group>";
 		};
 		OBJ_18 /* Generators */ = {
 			isa = PBXGroup;
 			children = (
 				OBJ_19 /* ColorStyles */,
+				OBJ_23 /* GenerationParametersError.swift */,
+				OBJ_24 /* GenerationParametersResolving.swift */,
 				OBJ_25 /* Images */,
 				OBJ_29 /* Library */,
 				OBJ_32 /* ShadowStyles */,
 				OBJ_36 /* TextStyles */,
-				OBJ_23 /* GenerationParametersError.swift */,
-				OBJ_24 /* GenerationParametersResolving.swift */,
 			);
 			path = Generators;
 			sourceTree = "<group>";
 		};
-		OBJ_182 /* ShadowStyles */ = {
+		OBJ_181 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_183 /* DefaultShadowStylesProvider.swift */,
-				OBJ_184 /* ShadowStylesProvider.swift */,
-				OBJ_185 /* ShadowStylesProviderError.swift */,
+				OBJ_182 /* DefaultImageResourcesProvider.swift */,
+				OBJ_183 /* ImageResourcesProvider.swift */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		OBJ_184 /* ShadowStyles */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_185 /* DefaultShadowStylesProvider.swift */,
+				OBJ_186 /* ShadowStylesProvider.swift */,
+				OBJ_187 /* ShadowStylesProviderError.swift */,
 			);
 			path = ShadowStyles;
 			sourceTree = "<group>";
 		};
-		OBJ_186 /* TextStyles */ = {
+		OBJ_188 /* TextStyles */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_187 /* DefaultTextStylesProvider.swift */,
-				OBJ_188 /* TextStylesProvider.swift */,
-				OBJ_189 /* TextStylesProviderError.swift */,
+				OBJ_189 /* DefaultTextStylesProvider.swift */,
+				OBJ_190 /* TextStylesProvider.swift */,
+				OBJ_191 /* TextStylesProviderError.swift */,
 			);
 			path = TextStyles;
 			sourceTree = "<group>";
@@ -1495,147 +1490,141 @@
 			path = ColorStyles;
 			sourceTree = "<group>";
 		};
-		OBJ_190 /* Render */ = {
+		OBJ_192 /* Render */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_196 /* StencilExtensions */,
-				OBJ_191 /* DefaultTemplateContextCoder.swift */,
-				OBJ_192 /* DefaultTemplateRenderer.swift */,
-				OBJ_193 /* RenderDestination.swift */,
-				OBJ_194 /* RenderTemplate.swift */,
-				OBJ_195 /* RenderTemplateType.swift */,
-				OBJ_218 /* TemplateContextCoder.swift */,
-				OBJ_219 /* TemplateRenderer.swift */,
+				OBJ_193 /* DefaultTemplateContextCoder.swift */,
+				OBJ_194 /* DefaultTemplateRenderer.swift */,
+				OBJ_195 /* RenderDestination.swift */,
+				OBJ_196 /* RenderTemplate.swift */,
+				OBJ_197 /* RenderTemplateType.swift */,
+				OBJ_198 /* StencilExtensions */,
+				OBJ_223 /* TemplateContextCoder.swift */,
+				OBJ_224 /* TemplateRenderer.swift */,
 			);
 			path = Render;
 			sourceTree = "<group>";
 		};
-		OBJ_196 /* StencilExtensions */ = {
+		OBJ_198 /* StencilExtensions */ = {
 			isa = PBXGroup;
 			children = (
-				C0BE783A24E9B258004EBBEF /* Vector */,
-				OBJ_197 /* Color */,
-				OBJ_204 /* Font */,
-				OBJ_207 /* Number */,
-				OBJ_212 /* StencilExtension.swift */,
-				OBJ_213 /* StencilFilter.swift */,
-				OBJ_214 /* StencilFilterError.swift */,
-				OBJ_215 /* StencilTag.swift */,
-				OBJ_216 /* StencilTagError.swift */,
-				OBJ_217 /* StencilTagNode.swift */,
+				OBJ_199 /* Color */,
+				OBJ_206 /* Font */,
+				OBJ_209 /* Number */,
+				OBJ_214 /* StencilExtension.swift */,
+				OBJ_215 /* StencilFilter.swift */,
+				OBJ_216 /* StencilFilterError.swift */,
+				8E53203E25330481006AA460 /* StencilModificator.swift */,
+				8E53203F25330481006AA460 /* StencilModificatorError.swift */,
+				OBJ_217 /* StencilTag.swift */,
+				OBJ_218 /* StencilTagError.swift */,
+				OBJ_219 /* StencilTagNode.swift */,
+				OBJ_220 /* Vector */,
 			);
 			path = StencilExtensions;
 			sourceTree = "<group>";
 		};
-		OBJ_197 /* Color */ = {
+		OBJ_199 /* Color */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_198 /* StencilColorFilter.swift */,
-				OBJ_199 /* StencilColorInfoFilter.swift */,
-				OBJ_200 /* StencilColorRGBAHexInfoFilter.swift */,
-				OBJ_201 /* StencilColorRGBAInfoFilter.swift */,
-				OBJ_202 /* StencilColorRGBHexInfoFilter.swift */,
-				OBJ_203 /* StencilColorRGBInfoFilter.swift */,
+				OBJ_200 /* StencilColorFilter.swift */,
+				OBJ_201 /* StencilColorInfoFilter.swift */,
+				OBJ_202 /* StencilColorRGBAHexInfoFilter.swift */,
+				OBJ_203 /* StencilColorRGBAInfoFilter.swift */,
+				OBJ_204 /* StencilColorRGBHexInfoFilter.swift */,
+				OBJ_205 /* StencilColorRGBInfoFilter.swift */,
 			);
 			path = Color;
 			sourceTree = "<group>";
 		};
-		OBJ_204 /* Font */ = {
+		OBJ_206 /* Font */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_205 /* StencilFontFilter.swift */,
-				OBJ_206 /* StencilFontInfoFilter.swift */,
+				OBJ_207 /* StencilFontFilter.swift */,
+				OBJ_208 /* StencilFontInfoFilter.swift */,
+				8E53205B25330490006AA460 /* StencilFontInitializerModificator.swift */,
+				8E53205A25330490006AA460 /* StencilFontModificator.swift */,
+				8E5320A625335F8A006AA460 /* StencilFontSystemFilter.swift */,
 			);
 			path = Font;
 			sourceTree = "<group>";
 		};
-		OBJ_207 /* Number */ = {
+		OBJ_209 /* Number */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_208 /* StencilByteToFloatFilter.swift */,
-				OBJ_209 /* StencilByteToHexFilter.swift */,
-				OBJ_210 /* StencilFloatToByteFilter.swift */,
-				OBJ_211 /* StencilHexToByteFilter.swift */,
+				OBJ_210 /* StencilByteToFloatFilter.swift */,
+				OBJ_211 /* StencilByteToHexFilter.swift */,
+				OBJ_212 /* StencilFloatToByteFilter.swift */,
+				OBJ_213 /* StencilHexToByteFilter.swift */,
 			);
 			path = Number;
 			sourceTree = "<group>";
 		};
-		OBJ_221 /* FugenTools */ = {
+		OBJ_220 /* Vector */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_222 /* Assets */,
-				OBJ_259 /* Extensions */,
-				OBJ_280 /* HTTPService */,
-				OBJ_309 /* Shared */,
-				OBJ_314 /* URLEncoder */,
-				C042748C24E84B5600E1605C /* .swiftlint.yml */,
+				OBJ_221 /* StencilVectorFilter.swift */,
+				OBJ_222 /* StencilVectorInfoFilter.swift */,
+			);
+			path = Vector;
+			sourceTree = "<group>";
+		};
+		OBJ_226 /* FugenTools */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_227 /* Assets */,
+				OBJ_264 /* Extensions */,
+				OBJ_285 /* HTTPService */,
+				OBJ_314 /* Shared */,
+				OBJ_319 /* URLEncoder */,
 			);
 			name = FugenTools;
 			path = Sources/FugenTools;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_222 /* Assets */ = {
+		OBJ_227 /* Assets */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_223 /* AssetAppearance.swift */,
-				OBJ_224 /* AssetAppearanceContrast.swift */,
-				OBJ_225 /* AssetAppearanceLuminosity.swift */,
-				OBJ_226 /* AssetCompressionType.swift */,
-				OBJ_227 /* AssetDisplayGamut.swift */,
-				OBJ_228 /* AssetIdiom.swift */,
-				OBJ_229 /* AssetIdiomIPadSubtype.swift */,
-				OBJ_230 /* AssetInfo.swift */,
-				OBJ_231 /* AssetNode.swift */,
-				OBJ_232 /* ColorSet */,
-				OBJ_242 /* Folder */,
-				OBJ_246 /* ImageSet */,
+				OBJ_228 /* AssetAppearance.swift */,
+				OBJ_229 /* AssetAppearanceContrast.swift */,
+				OBJ_230 /* AssetAppearanceLuminosity.swift */,
+				OBJ_231 /* AssetCompressionType.swift */,
+				OBJ_232 /* AssetDisplayGamut.swift */,
+				OBJ_233 /* AssetIdiom.swift */,
+				OBJ_234 /* AssetIdiomIPadSubtype.swift */,
+				OBJ_235 /* AssetInfo.swift */,
+				OBJ_236 /* AssetNode.swift */,
+				OBJ_237 /* ColorSet */,
+				OBJ_247 /* Folder */,
+				OBJ_251 /* ImageSet */,
 			);
 			path = Assets;
 			sourceTree = "<group>";
 		};
-		OBJ_232 /* ColorSet */ = {
+		OBJ_237 /* ColorSet */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_233 /* AssetColor.swift */,
-				OBJ_234 /* AssetColorComponents.swift */,
-				OBJ_235 /* AssetColorContent.swift */,
-				OBJ_236 /* AssetColorGrayscale.swift */,
-				OBJ_237 /* AssetColorSet.swift */,
-				OBJ_238 /* AssetColorSetContents.swift */,
-				OBJ_239 /* AssetCustomColor.swift */,
-				OBJ_240 /* AssetSystemColor.swift */,
-				OBJ_241 /* AssetSystemColorPlatform.swift */,
+				OBJ_238 /* AssetColor.swift */,
+				OBJ_239 /* AssetColorComponents.swift */,
+				OBJ_240 /* AssetColorContent.swift */,
+				OBJ_241 /* AssetColorGrayscale.swift */,
+				OBJ_242 /* AssetColorSet.swift */,
+				OBJ_243 /* AssetColorSetContents.swift */,
+				OBJ_244 /* AssetCustomColor.swift */,
+				OBJ_245 /* AssetSystemColor.swift */,
+				OBJ_246 /* AssetSystemColorPlatform.swift */,
 			);
 			path = ColorSet;
 			sourceTree = "<group>";
 		};
-		OBJ_242 /* Folder */ = {
+		OBJ_247 /* Folder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_243 /* AssetFolder.swift */,
-				OBJ_244 /* AssetFolderContents.swift */,
-				OBJ_245 /* AssetFolderProperties.swift */,
+				OBJ_248 /* AssetFolder.swift */,
+				OBJ_249 /* AssetFolderContents.swift */,
+				OBJ_250 /* AssetFolderProperties.swift */,
 			);
 			path = Folder;
-			sourceTree = "<group>";
-		};
-		OBJ_246 /* ImageSet */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_247 /* AssetImage.swift */,
-				OBJ_248 /* AssetImageAlignmentInsets.swift */,
-				OBJ_249 /* AssetImageAutoScaling.swift */,
-				OBJ_250 /* AssetImageGraphicsFeatureSet.swift */,
-				OBJ_251 /* AssetImageLanguageDirection.swift */,
-				OBJ_252 /* AssetImageMemory.swift */,
-				OBJ_253 /* AssetImageProperties.swift */,
-				OBJ_254 /* AssetImageScale.swift */,
-				OBJ_255 /* AssetImageSet.swift */,
-				OBJ_256 /* AssetImageSetContents.swift */,
-				OBJ_257 /* AssetImageSizeClass.swift */,
-				OBJ_258 /* AssetImageTemplateRenderingIntent.swift */,
-			);
-			path = ImageSet;
 			sourceTree = "<group>";
 		};
 		OBJ_25 /* Images */ = {
@@ -1648,62 +1637,81 @@
 			path = Images;
 			sourceTree = "<group>";
 		};
-		OBJ_259 /* Extensions */ = {
+		OBJ_251 /* ImageSet */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_260 /* Bundle+Extensions.swift */,
-				OBJ_261 /* CLI+Extensions.swift */,
-				OBJ_262 /* Collection+Extensions.swift */,
-				OBJ_263 /* Decodable+Extensions.swift */,
-				OBJ_264 /* DispatchQueue+Extensions.swift */,
-				OBJ_265 /* Encodable+Extensions.swift */,
-				OBJ_266 /* FloatingPoint+Extensions.swift */,
-				OBJ_267 /* JSONDecoder+Extensions.swift */,
-				OBJ_268 /* JSONEncoder+Extensions.swift */,
-				OBJ_269 /* KeyedDecodingContainerProtocol+Extensions.swift */,
-				OBJ_270 /* OperatingSystemVersion+Extensions.swift */,
-				OBJ_271 /* Optional+Extensions.swift */,
-				OBJ_272 /* Path+Extensions.swift */,
-				OBJ_273 /* ProcessInfo+Extensions.swift */,
-				OBJ_274 /* Promise+Extensions.swift */,
-				OBJ_275 /* RangeReplaceableCollection+Extensions.swift */,
-				OBJ_276 /* Sequence+Extensions.swift */,
-				OBJ_277 /* SingleValueDecodingContainer+Extensions.swift */,
-				OBJ_278 /* String+Extensions.swift */,
-				OBJ_279 /* UnkeyedDecodingContainer+Extensions.swift */,
+				OBJ_252 /* AssetImage.swift */,
+				OBJ_253 /* AssetImageAlignmentInsets.swift */,
+				OBJ_254 /* AssetImageAutoScaling.swift */,
+				OBJ_255 /* AssetImageGraphicsFeatureSet.swift */,
+				OBJ_256 /* AssetImageLanguageDirection.swift */,
+				OBJ_257 /* AssetImageMemory.swift */,
+				OBJ_258 /* AssetImageProperties.swift */,
+				OBJ_259 /* AssetImageScale.swift */,
+				OBJ_260 /* AssetImageSet.swift */,
+				OBJ_261 /* AssetImageSetContents.swift */,
+				OBJ_262 /* AssetImageSizeClass.swift */,
+				OBJ_263 /* AssetImageTemplateRenderingIntent.swift */,
+			);
+			path = ImageSet;
+			sourceTree = "<group>";
+		};
+		OBJ_264 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_265 /* Bundle+Extensions.swift */,
+				OBJ_266 /* CLI+Extensions.swift */,
+				OBJ_267 /* Collection+Extensions.swift */,
+				OBJ_268 /* Decodable+Extensions.swift */,
+				OBJ_269 /* DispatchQueue+Extensions.swift */,
+				OBJ_270 /* Encodable+Extensions.swift */,
+				OBJ_271 /* FloatingPoint+Extensions.swift */,
+				OBJ_272 /* JSONDecoder+Extensions.swift */,
+				OBJ_273 /* JSONEncoder+Extensions.swift */,
+				OBJ_274 /* KeyedDecodingContainerProtocol+Extensions.swift */,
+				OBJ_275 /* OperatingSystemVersion+Extensions.swift */,
+				OBJ_276 /* Optional+Extensions.swift */,
+				OBJ_277 /* Path+Extensions.swift */,
+				OBJ_278 /* ProcessInfo+Extensions.swift */,
+				OBJ_279 /* Promise+Extensions.swift */,
+				OBJ_280 /* RangeReplaceableCollection+Extensions.swift */,
+				OBJ_281 /* Sequence+Extensions.swift */,
+				OBJ_282 /* SingleValueDecodingContainer+Extensions.swift */,
+				OBJ_283 /* String+Extensions.swift */,
+				OBJ_284 /* UnkeyedDecodingContainer+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
 		};
-		OBJ_280 /* HTTPService */ = {
+		OBJ_285 /* HTTPService */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_281 /* BodyEncoders */,
-				OBJ_298 /* QueryEncoders */,
-				OBJ_301 /* ResponseSerializers */,
-				OBJ_285 /* HTTPActivityIndicator.swift */,
-				OBJ_286 /* HTTPAnyEncodable.swift */,
-				OBJ_287 /* HTTPError.swift */,
-				OBJ_288 /* HTTPErrorStringConvertible.swift */,
-				OBJ_289 /* HTTPHeader.swift */,
-				OBJ_290 /* HTTPMethod.swift */,
-				OBJ_291 /* HTTPResponse.swift */,
-				OBJ_292 /* HTTPRoute.swift */,
-				OBJ_293 /* HTTPService.swift */,
-				OBJ_294 /* HTTPServiceTask.swift */,
-				OBJ_295 /* HTTPStatusCode.swift */,
-				OBJ_296 /* HTTPTask.swift */,
-				OBJ_297 /* HTTPUIActivityIndicator.swift */,
+				OBJ_286 /* BodyEncoders */,
+				OBJ_290 /* HTTPActivityIndicator.swift */,
+				OBJ_291 /* HTTPAnyEncodable.swift */,
+				OBJ_292 /* HTTPError.swift */,
+				OBJ_293 /* HTTPErrorStringConvertible.swift */,
+				OBJ_294 /* HTTPHeader.swift */,
+				OBJ_295 /* HTTPMethod.swift */,
+				OBJ_296 /* HTTPResponse.swift */,
+				OBJ_297 /* HTTPRoute.swift */,
+				OBJ_298 /* HTTPService.swift */,
+				OBJ_299 /* HTTPServiceTask.swift */,
+				OBJ_300 /* HTTPStatusCode.swift */,
+				OBJ_301 /* HTTPTask.swift */,
+				OBJ_302 /* HTTPUIActivityIndicator.swift */,
+				OBJ_303 /* QueryEncoders */,
+				OBJ_306 /* ResponseSerializers */,
 			);
 			path = HTTPService;
 			sourceTree = "<group>";
 		};
-		OBJ_281 /* BodyEncoders */ = {
+		OBJ_286 /* BodyEncoders */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_282 /* HTTPBodyEncoder.swift */,
-				OBJ_283 /* HTTPBodyJSONEncoder.swift */,
-				OBJ_284 /* HTTPBodyURLEncoder.swift */,
+				OBJ_287 /* HTTPBodyEncoder.swift */,
+				OBJ_288 /* HTTPBodyJSONEncoder.swift */,
+				OBJ_289 /* HTTPBodyURLEncoder.swift */,
 			);
 			path = BodyEncoders;
 			sourceTree = "<group>";
@@ -1717,56 +1725,56 @@
 			path = Library;
 			sourceTree = "<group>";
 		};
-		OBJ_298 /* QueryEncoders */ = {
+		OBJ_303 /* QueryEncoders */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_299 /* HTTPQueryEncoder.swift */,
-				OBJ_300 /* HTTPQueryURLEncoder.swift */,
+				OBJ_304 /* HTTPQueryEncoder.swift */,
+				OBJ_305 /* HTTPQueryURLEncoder.swift */,
 			);
 			path = QueryEncoders;
 			sourceTree = "<group>";
 		};
-		OBJ_301 /* ResponseSerializers */ = {
+		OBJ_306 /* ResponseSerializers */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_302 /* HTTPDataResponseSerializer.swift */,
-				OBJ_303 /* HTTPDecodableResponseSerializer.swift */,
-				OBJ_304 /* HTTPEmptyResponse.swift */,
-				OBJ_305 /* HTTPJSONResponseSerializer.swift */,
-				OBJ_306 /* HTTPResponseDecoder.swift */,
-				OBJ_307 /* HTTPResponseSerializer.swift */,
-				OBJ_308 /* HTTPStringResponseSerializer.swift */,
+				OBJ_307 /* HTTPDataResponseSerializer.swift */,
+				OBJ_308 /* HTTPDecodableResponseSerializer.swift */,
+				OBJ_309 /* HTTPEmptyResponse.swift */,
+				OBJ_310 /* HTTPJSONResponseSerializer.swift */,
+				OBJ_311 /* HTTPResponseDecoder.swift */,
+				OBJ_312 /* HTTPResponseSerializer.swift */,
+				OBJ_313 /* HTTPStringResponseSerializer.swift */,
 			);
 			path = ResponseSerializers;
 			sourceTree = "<group>";
 		};
-		OBJ_309 /* Shared */ = {
+		OBJ_314 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_310 /* AnyCodable.swift */,
-				OBJ_311 /* AnyCodingKey.swift */,
-				OBJ_312 /* Cache.swift */,
-				OBJ_313 /* MessageError.swift */,
+				OBJ_315 /* AnyCodable.swift */,
+				OBJ_316 /* AnyCodingKey.swift */,
+				OBJ_317 /* Cache.swift */,
+				OBJ_318 /* MessageError.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
 		};
-		OBJ_314 /* URLEncoder */ = {
+		OBJ_319 /* URLEncoder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_315 /* URLArrayEncodingStrategy.swift */,
-				OBJ_316 /* URLBoolEncodingStrategy.swift */,
-				OBJ_317 /* URLDateEncodingStrategy.swift */,
-				OBJ_318 /* URLEncodedForm.swift */,
-				OBJ_319 /* URLEncodedFormComponent.swift */,
-				OBJ_320 /* URLEncodedFormContext.swift */,
-				OBJ_321 /* URLEncodedFormEncoder.swift */,
-				OBJ_322 /* URLEncodedFormKeyedEncodingContainer.swift */,
-				OBJ_323 /* URLEncodedFormSerializer.swift */,
-				OBJ_324 /* URLEncodedFormSingleValueEncodingContainer.swift */,
-				OBJ_325 /* URLEncodedFormUnkeyedEncodingContainer.swift */,
-				OBJ_326 /* URLEncoder.swift */,
-				OBJ_327 /* URLSpaceEncodingStrategy.swift */,
+				OBJ_320 /* URLArrayEncodingStrategy.swift */,
+				OBJ_321 /* URLBoolEncodingStrategy.swift */,
+				OBJ_322 /* URLDateEncodingStrategy.swift */,
+				OBJ_323 /* URLEncodedForm.swift */,
+				OBJ_324 /* URLEncodedFormComponent.swift */,
+				OBJ_325 /* URLEncodedFormContext.swift */,
+				OBJ_326 /* URLEncodedFormEncoder.swift */,
+				OBJ_327 /* URLEncodedFormKeyedEncodingContainer.swift */,
+				OBJ_328 /* URLEncodedFormSerializer.swift */,
+				OBJ_329 /* URLEncodedFormSingleValueEncodingContainer.swift */,
+				OBJ_330 /* URLEncodedFormUnkeyedEncodingContainer.swift */,
+				OBJ_331 /* URLEncoder.swift */,
+				OBJ_332 /* URLSpaceEncodingStrategy.swift */,
 			);
 			path = URLEncoder;
 			sourceTree = "<group>";
@@ -1781,104 +1789,102 @@
 			path = ShadowStyles;
 			sourceTree = "<group>";
 		};
-		OBJ_328 /* Tests */ = {
+		OBJ_333 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_329 /* FugenTests */,
-				OBJ_333 /* FugenToolsTests */,
-				C042748E24E84B8800E1605C /* .swiftlint.yml */,
-				C042748D24E84B6D00E1605C /* LinuxMain.swift */,
+				OBJ_334 /* FugenTests */,
+				OBJ_338 /* FugenToolsTests */,
 			);
 			name = Tests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_329 /* FugenTests */ = {
+		OBJ_334 /* FugenTests */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_330 /* Info.plist */,
-				OBJ_331 /* FugenTests.swift */,
-				OBJ_332 /* XCTestManifests.swift */,
+				OBJ_335 /* Info.plist */,
+				OBJ_336 /* FugenTests.swift */,
+				OBJ_337 /* XCTestManifests.swift */,
 			);
 			name = FugenTests;
 			path = Tests/FugenTests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_333 /* FugenToolsTests */ = {
+		OBJ_338 /* FugenToolsTests */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_334 /* Info.plist */,
-				OBJ_335 /* FugenToolsTests.swift */,
-				OBJ_336 /* XCTestManifests.swift */,
+				OBJ_339 /* Info.plist */,
+				OBJ_340 /* FugenToolsTests.swift */,
+				OBJ_341 /* XCTestManifests.swift */,
 			);
 			name = FugenToolsTests;
 			path = Tests/FugenToolsTests;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_337 /* Dependencies */ = {
+		OBJ_342 /* Dependencies */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_338 /* DictionaryCoder 1.0.0 */,
-				OBJ_371 /* PromiseKit 6.13.1 */,
-				OBJ_388 /* StencilSwiftKit 2.7.2 */,
-				OBJ_402 /* Stencil 0.13.1 */,
-				OBJ_424 /* PathKit 0.9.2 */,
-				OBJ_427 /* Yams 2.0.0 */,
-				OBJ_457 /* Rainbow 3.1.5 */,
-				OBJ_470 /* SwiftCLI 5.3.3 */,
+				OBJ_343 /* DictionaryCoder 1.0.2 */,
+				OBJ_376 /* PromiseKit 6.13.2 */,
+				OBJ_393 /* StencilSwiftKit 2.7.2 */,
+				OBJ_407 /* Stencil 0.13.1 */,
+				OBJ_429 /* PathKit 0.9.2 */,
+				OBJ_432 /* Yams 2.0.0 */,
+				OBJ_462 /* Rainbow 3.1.5 */,
+				OBJ_475 /* SwiftCLI 5.3.3 */,
 			);
 			name = Dependencies;
 			sourceTree = "<group>";
 		};
-		OBJ_338 /* DictionaryCoder 1.0.0 */ = {
+		OBJ_343 /* DictionaryCoder 1.0.2 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_339 /* Package.swift */,
-				OBJ_340 /* Decoder */,
-				OBJ_352 /* Encoder */,
-				OBJ_367 /* Tools */,
+				OBJ_344 /* Package.swift */,
+				OBJ_345 /* Decoder */,
+				OBJ_357 /* Encoder */,
+				OBJ_372 /* Tools */,
 			);
-			name = "DictionaryCoder 1.0.0";
+			name = "DictionaryCoder 1.0.2";
 			path = .build/checkouts/DictionaryCoder/Sources;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_340 /* Decoder */ = {
+		OBJ_345 /* Decoder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_341 /* DictionaryComponentDecoder.swift */,
-				OBJ_342 /* DictionaryDecoder.swift */,
-				OBJ_343 /* DictionaryDecodingOptions.swift */,
-				OBJ_344 /* DictionaryKeyedDecodingContainer.swift */,
-				OBJ_345 /* DictionarySingleValueDecodingContainer.swift */,
-				OBJ_346 /* DictionaryUnkeyedDecodingContainer.swift */,
-				OBJ_347 /* Strategies */,
+				OBJ_346 /* DictionaryComponentDecoder.swift */,
+				OBJ_347 /* DictionaryDecoder.swift */,
+				OBJ_348 /* DictionaryDecodingOptions.swift */,
+				OBJ_349 /* DictionaryKeyedDecodingContainer.swift */,
+				OBJ_350 /* DictionarySingleValueDecodingContainer.swift */,
+				OBJ_351 /* DictionaryUnkeyedDecodingContainer.swift */,
+				OBJ_352 /* Strategies */,
 			);
 			path = Decoder;
 			sourceTree = "<group>";
 		};
-		OBJ_347 /* Strategies */ = {
+		OBJ_352 /* Strategies */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_348 /* DictionaryDataDecodingStrategy.swift */,
-				OBJ_349 /* DictionaryDateDecodingStrategy.swift */,
-				OBJ_350 /* DictionaryKeyDecodingStrategy.swift */,
-				OBJ_351 /* DictionaryNonConformingFloatDecodingStrategy.swift */,
+				OBJ_353 /* DictionaryDataDecodingStrategy.swift */,
+				OBJ_354 /* DictionaryDateDecodingStrategy.swift */,
+				OBJ_355 /* DictionaryKeyDecodingStrategy.swift */,
+				OBJ_356 /* DictionaryNonConformingFloatDecodingStrategy.swift */,
 			);
 			path = Strategies;
 			sourceTree = "<group>";
 		};
-		OBJ_352 /* Encoder */ = {
+		OBJ_357 /* Encoder */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_353 /* DictionaryAnyKeyedEncodingContainer.swift */,
-				OBJ_354 /* DictionaryComponent.swift */,
-				OBJ_355 /* DictionaryComponentContainer.swift */,
-				OBJ_356 /* DictionaryComponentEncoder.swift */,
-				OBJ_357 /* DictionaryEncoder.swift */,
-				OBJ_358 /* DictionaryEncodingOptions.swift */,
-				OBJ_359 /* DictionaryKeyedEncodingContainer.swift */,
-				OBJ_360 /* DictionarySingleValueEncodingContainer.swift */,
-				OBJ_361 /* DictionaryUnkeyedEncodingContainer.swift */,
-				OBJ_362 /* Strategies */,
+				OBJ_358 /* DictionaryAnyKeyedEncodingContainer.swift */,
+				OBJ_359 /* DictionaryComponent.swift */,
+				OBJ_360 /* DictionaryComponentContainer.swift */,
+				OBJ_361 /* DictionaryComponentEncoder.swift */,
+				OBJ_362 /* DictionaryEncoder.swift */,
+				OBJ_363 /* DictionaryEncodingOptions.swift */,
+				OBJ_364 /* DictionaryKeyedEncodingContainer.swift */,
+				OBJ_365 /* DictionarySingleValueEncodingContainer.swift */,
+				OBJ_366 /* DictionaryUnkeyedEncodingContainer.swift */,
+				OBJ_367 /* Strategies */,
 			);
 			path = Encoder;
 			sourceTree = "<group>";
@@ -1893,74 +1899,74 @@
 			path = TextStyles;
 			sourceTree = "<group>";
 		};
-		OBJ_362 /* Strategies */ = {
+		OBJ_367 /* Strategies */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_363 /* DictionaryDataEncodingStrategy.swift */,
-				OBJ_364 /* DictionaryDateEncodingStrategy.swift */,
-				OBJ_365 /* DictionaryKeyEncodingStrategy.swift */,
-				OBJ_366 /* DictionaryNonConformingFloatEncodingStrategy.swift */,
+				OBJ_368 /* DictionaryDataEncodingStrategy.swift */,
+				OBJ_369 /* DictionaryDateEncodingStrategy.swift */,
+				OBJ_370 /* DictionaryKeyEncodingStrategy.swift */,
+				OBJ_371 /* DictionaryNonConformingFloatEncodingStrategy.swift */,
 			);
 			path = Strategies;
 			sourceTree = "<group>";
 		};
-		OBJ_367 /* Tools */ = {
+		OBJ_372 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_368 /* AnyCodingKey.swift */,
-				OBJ_369 /* Optional+Extensions.swift */,
-				OBJ_370 /* RangeReplaceableCollection+Extensions.swift */,
+				OBJ_373 /* AnyCodingKey.swift */,
+				OBJ_374 /* Optional+Extensions.swift */,
+				OBJ_375 /* RangeReplaceableCollection+Extensions.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
 		};
-		OBJ_371 /* PromiseKit 6.13.1 */ = {
+		OBJ_376 /* PromiseKit 6.13.2 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_372 /* Package.swift */,
-				OBJ_373 /* Box.swift */,
-				OBJ_374 /* Catchable.swift */,
-				OBJ_375 /* Configuration.swift */,
-				OBJ_376 /* CustomStringConvertible.swift */,
-				OBJ_377 /* Error.swift */,
-				OBJ_378 /* Guarantee.swift */,
-				OBJ_379 /* LogEvent.swift */,
-				OBJ_380 /* Promise.swift */,
-				OBJ_381 /* Resolver.swift */,
-				OBJ_382 /* Thenable.swift */,
-				OBJ_383 /* after.swift */,
-				OBJ_384 /* firstly.swift */,
-				OBJ_385 /* hang.swift */,
-				OBJ_386 /* race.swift */,
-				OBJ_387 /* when.swift */,
+				OBJ_377 /* Package.swift */,
+				OBJ_378 /* Box.swift */,
+				OBJ_379 /* Catchable.swift */,
+				OBJ_380 /* Configuration.swift */,
+				OBJ_381 /* CustomStringConvertible.swift */,
+				OBJ_382 /* Error.swift */,
+				OBJ_383 /* Guarantee.swift */,
+				OBJ_384 /* LogEvent.swift */,
+				OBJ_385 /* Promise.swift */,
+				OBJ_386 /* Resolver.swift */,
+				OBJ_387 /* Thenable.swift */,
+				OBJ_388 /* after.swift */,
+				OBJ_389 /* firstly.swift */,
+				OBJ_390 /* hang.swift */,
+				OBJ_391 /* race.swift */,
+				OBJ_392 /* when.swift */,
 			);
-			name = "PromiseKit 6.13.1";
+			name = "PromiseKit 6.13.2";
 			path = .build/checkouts/PromiseKit/Sources;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_388 /* StencilSwiftKit 2.7.2 */ = {
+		OBJ_393 /* StencilSwiftKit 2.7.2 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_389 /* StencilSwiftKit */,
-				OBJ_401 /* Package.swift */,
+				OBJ_394 /* StencilSwiftKit */,
+				OBJ_406 /* Package.swift */,
 			);
 			name = "StencilSwiftKit 2.7.2";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_389 /* StencilSwiftKit */ = {
+		OBJ_394 /* StencilSwiftKit */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_390 /* CallMacroNodes.swift */,
-				OBJ_391 /* Context.swift */,
-				OBJ_392 /* Environment.swift */,
-				OBJ_393 /* Filters+Numbers.swift */,
-				OBJ_394 /* Filters+Strings.swift */,
-				OBJ_395 /* Filters.swift */,
-				OBJ_396 /* MapNode.swift */,
-				OBJ_397 /* Parameters.swift */,
-				OBJ_398 /* SetNode.swift */,
-				OBJ_399 /* StencilSwiftTemplate.swift */,
-				OBJ_400 /* SwiftIdentifier.swift */,
+				OBJ_395 /* CallMacroNodes.swift */,
+				OBJ_396 /* Context.swift */,
+				OBJ_397 /* Environment.swift */,
+				OBJ_398 /* Filters+Numbers.swift */,
+				OBJ_399 /* Filters+Strings.swift */,
+				OBJ_400 /* Filters.swift */,
+				OBJ_401 /* MapNode.swift */,
+				OBJ_402 /* Parameters.swift */,
+				OBJ_403 /* SetNode.swift */,
+				OBJ_404 /* StencilSwiftTemplate.swift */,
+				OBJ_405 /* SwiftIdentifier.swift */,
 			);
 			name = StencilSwiftKit;
 			path = .build/checkouts/StencilSwiftKit/Sources/StencilSwiftKit;
@@ -1969,43 +1975,43 @@
 		OBJ_40 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				OBJ_41 /* Color.swift */,
 				OBJ_42 /* ColorStyle */,
 				OBJ_46 /* Configuration */,
+				OBJ_56 /* Font.swift */,
 				OBJ_57 /* Images */,
 				OBJ_65 /* Parameters */,
 				OBJ_71 /* ShadowStyle */,
-				OBJ_74 /* TextStyle */,
-				OBJ_41 /* Color.swift */,
-				OBJ_56 /* Font.swift */,
-				OBJ_78 /* Vector.swift */,
+				OBJ_76 /* TextStyle */,
+				OBJ_80 /* Vector.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
 		};
-		OBJ_402 /* Stencil 0.13.1 */ = {
+		OBJ_407 /* Stencil 0.13.1 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_403 /* Package.swift */,
-				OBJ_404 /* Context.swift */,
-				OBJ_405 /* Environment.swift */,
-				OBJ_406 /* Errors.swift */,
-				OBJ_407 /* Expression.swift */,
-				OBJ_408 /* Extension.swift */,
-				OBJ_409 /* FilterTag.swift */,
-				OBJ_410 /* Filters.swift */,
-				OBJ_411 /* ForTag.swift */,
-				OBJ_412 /* IfTag.swift */,
-				OBJ_413 /* Include.swift */,
-				OBJ_414 /* Inheritence.swift */,
-				OBJ_415 /* KeyPath.swift */,
-				OBJ_416 /* Lexer.swift */,
-				OBJ_417 /* Loader.swift */,
-				OBJ_418 /* Node.swift */,
-				OBJ_419 /* NowTag.swift */,
-				OBJ_420 /* Parser.swift */,
-				OBJ_421 /* Template.swift */,
-				OBJ_422 /* Tokenizer.swift */,
-				OBJ_423 /* Variable.swift */,
+				OBJ_408 /* Package.swift */,
+				OBJ_409 /* Context.swift */,
+				OBJ_410 /* Environment.swift */,
+				OBJ_411 /* Errors.swift */,
+				OBJ_412 /* Expression.swift */,
+				OBJ_413 /* Extension.swift */,
+				OBJ_414 /* FilterTag.swift */,
+				OBJ_415 /* Filters.swift */,
+				OBJ_416 /* ForTag.swift */,
+				OBJ_417 /* IfTag.swift */,
+				OBJ_418 /* Include.swift */,
+				OBJ_419 /* Inheritence.swift */,
+				OBJ_420 /* KeyPath.swift */,
+				OBJ_421 /* Lexer.swift */,
+				OBJ_422 /* Loader.swift */,
+				OBJ_423 /* Node.swift */,
+				OBJ_424 /* NowTag.swift */,
+				OBJ_425 /* Parser.swift */,
+				OBJ_426 /* Template.swift */,
+				OBJ_427 /* Tokenizer.swift */,
+				OBJ_428 /* Variable.swift */,
 			);
 			name = "Stencil 0.13.1";
 			path = .build/checkouts/Stencil/Sources;
@@ -2021,100 +2027,80 @@
 			path = ColorStyle;
 			sourceTree = "<group>";
 		};
-		OBJ_424 /* PathKit 0.9.2 */ = {
+		OBJ_429 /* PathKit 0.9.2 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_425 /* Package.swift */,
-				OBJ_426 /* PathKit.swift */,
+				OBJ_430 /* Package.swift */,
+				OBJ_431 /* PathKit.swift */,
 			);
 			name = "PathKit 0.9.2";
 			path = .build/checkouts/PathKit/Sources;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_427 /* Yams 2.0.0 */ = {
+		OBJ_432 /* Yams 2.0.0 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_428 /* CYaml */,
-				OBJ_439 /* Yams */,
-				OBJ_456 /* Package.swift */,
+				OBJ_433 /* CYaml */,
+				OBJ_444 /* Yams */,
+				OBJ_461 /* Package.swift */,
 			);
 			name = "Yams 2.0.0";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_428 /* CYaml */ = {
+		OBJ_433 /* CYaml */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_429 /* src */,
-				OBJ_436 /* include */,
+				OBJ_434 /* src */,
+				OBJ_441 /* include */,
 			);
 			name = CYaml;
 			path = .build/checkouts/Yams/Sources/CYaml;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_429 /* src */ = {
+		OBJ_434 /* src */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_430 /* api.c */,
-				OBJ_431 /* emitter.c */,
-				OBJ_432 /* parser.c */,
-				OBJ_433 /* reader.c */,
-				OBJ_434 /* scanner.c */,
-				OBJ_435 /* writer.c */,
+				OBJ_435 /* api.c */,
+				OBJ_436 /* emitter.c */,
+				OBJ_437 /* parser.c */,
+				OBJ_438 /* reader.c */,
+				OBJ_439 /* scanner.c */,
+				OBJ_440 /* writer.c */,
 			);
 			path = src;
 			sourceTree = "<group>";
 		};
-		OBJ_436 /* include */ = {
+		OBJ_441 /* include */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_437 /* CYaml.h */,
-				OBJ_438 /* yaml.h */,
+				OBJ_442 /* CYaml.h */,
+				OBJ_443 /* yaml.h */,
 			);
 			path = include;
 			sourceTree = "<group>";
 		};
-		OBJ_439 /* Yams */ = {
+		OBJ_444 /* Yams */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_440 /* Constructor.swift */,
-				OBJ_441 /* Decoder.swift */,
-				OBJ_442 /* Emitter.swift */,
-				OBJ_443 /* Encoder.swift */,
-				OBJ_444 /* Mark.swift */,
-				OBJ_445 /* Node.Mapping.swift */,
-				OBJ_446 /* Node.Scalar.swift */,
-				OBJ_447 /* Node.Sequence.swift */,
-				OBJ_448 /* Node.swift */,
-				OBJ_449 /* Parser.swift */,
-				OBJ_450 /* Representer.swift */,
-				OBJ_451 /* Resolver.swift */,
-				OBJ_452 /* String+Yams.swift */,
-				OBJ_453 /* Tag.swift */,
-				OBJ_454 /* YamlError.swift */,
-				OBJ_455 /* shim.swift */,
+				OBJ_445 /* Constructor.swift */,
+				OBJ_446 /* Decoder.swift */,
+				OBJ_447 /* Emitter.swift */,
+				OBJ_448 /* Encoder.swift */,
+				OBJ_449 /* Mark.swift */,
+				OBJ_450 /* Node.Mapping.swift */,
+				OBJ_451 /* Node.Scalar.swift */,
+				OBJ_452 /* Node.Sequence.swift */,
+				OBJ_453 /* Node.swift */,
+				OBJ_454 /* Parser.swift */,
+				OBJ_455 /* Representer.swift */,
+				OBJ_456 /* Resolver.swift */,
+				OBJ_457 /* String+Yams.swift */,
+				OBJ_458 /* Tag.swift */,
+				OBJ_459 /* YamlError.swift */,
+				OBJ_460 /* shim.swift */,
 			);
 			name = Yams;
 			path = .build/checkouts/Yams/Sources/Yams;
-			sourceTree = SOURCE_ROOT;
-		};
-		OBJ_457 /* Rainbow 3.1.5 */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_458 /* Package.swift */,
-				OBJ_459 /* BackgroundColor.swift */,
-				OBJ_460 /* CodesParser.swift */,
-				OBJ_461 /* Color.swift */,
-				OBJ_462 /* ControlCode.swift */,
-				OBJ_463 /* ModesExtractor.swift */,
-				OBJ_464 /* OutputTarget.swift */,
-				OBJ_465 /* Rainbow.swift */,
-				OBJ_466 /* String+Rainbow.swift */,
-				OBJ_467 /* StringGenerator.swift */,
-				OBJ_468 /* Style.swift */,
-				OBJ_469 /* XcodeColorsSupport.swift */,
-			);
-			name = "Rainbow 3.1.5";
-			path = .build/checkouts/Rainbow/Sources;
 			sourceTree = SOURCE_ROOT;
 		};
 		OBJ_46 /* Configuration */ = {
@@ -2133,91 +2119,109 @@
 			path = Configuration;
 			sourceTree = "<group>";
 		};
-		OBJ_470 /* SwiftCLI 5.3.3 */ = {
+		OBJ_462 /* Rainbow 3.1.5 */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_471 /* SwiftCLI */,
-				OBJ_494 /* Package.swift */,
+				OBJ_463 /* Package.swift */,
+				OBJ_464 /* BackgroundColor.swift */,
+				OBJ_465 /* CodesParser.swift */,
+				OBJ_466 /* Color.swift */,
+				OBJ_467 /* ControlCode.swift */,
+				OBJ_468 /* ModesExtractor.swift */,
+				OBJ_469 /* OutputTarget.swift */,
+				OBJ_470 /* Rainbow.swift */,
+				OBJ_471 /* String+Rainbow.swift */,
+				OBJ_472 /* StringGenerator.swift */,
+				OBJ_473 /* Style.swift */,
+				OBJ_474 /* XcodeColorsSupport.swift */,
+			);
+			name = "Rainbow 3.1.5";
+			path = .build/checkouts/Rainbow/Sources;
+			sourceTree = SOURCE_ROOT;
+		};
+		OBJ_475 /* SwiftCLI 5.3.3 */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_476 /* SwiftCLI */,
+				OBJ_499 /* Package.swift */,
 			);
 			name = "SwiftCLI 5.3.3";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_471 /* SwiftCLI */ = {
+		OBJ_476 /* SwiftCLI */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_472 /* ArgumentList.swift */,
-				OBJ_473 /* ArgumentListManipulator.swift */,
-				OBJ_474 /* CLI.swift */,
-				OBJ_475 /* Command.swift */,
-				OBJ_476 /* Compatibility.swift */,
-				OBJ_477 /* CompletionGenerator.swift */,
-				OBJ_478 /* Error.swift */,
-				OBJ_479 /* HelpCommand.swift */,
-				OBJ_480 /* HelpMessageGenerator.swift */,
-				OBJ_481 /* Input.swift */,
-				OBJ_482 /* Option.swift */,
-				OBJ_483 /* OptionGroup.swift */,
-				OBJ_484 /* OptionRegistry.swift */,
-				OBJ_485 /* Parameter.swift */,
-				OBJ_486 /* Parser.swift */,
-				OBJ_487 /* Path.swift */,
-				OBJ_488 /* Stream.swift */,
-				OBJ_489 /* Task.swift */,
-				OBJ_490 /* Term.swift */,
-				OBJ_491 /* Validation.swift */,
-				OBJ_492 /* ValueBox.swift */,
-				OBJ_493 /* VersionCommand.swift */,
+				OBJ_477 /* ArgumentList.swift */,
+				OBJ_478 /* ArgumentListManipulator.swift */,
+				OBJ_479 /* CLI.swift */,
+				OBJ_480 /* Command.swift */,
+				OBJ_481 /* Compatibility.swift */,
+				OBJ_482 /* CompletionGenerator.swift */,
+				OBJ_483 /* Error.swift */,
+				OBJ_484 /* HelpCommand.swift */,
+				OBJ_485 /* HelpMessageGenerator.swift */,
+				OBJ_486 /* Input.swift */,
+				OBJ_487 /* Option.swift */,
+				OBJ_488 /* OptionGroup.swift */,
+				OBJ_489 /* OptionRegistry.swift */,
+				OBJ_490 /* Parameter.swift */,
+				OBJ_491 /* Parser.swift */,
+				OBJ_492 /* Path.swift */,
+				OBJ_493 /* Stream.swift */,
+				OBJ_494 /* Task.swift */,
+				OBJ_495 /* Term.swift */,
+				OBJ_496 /* Validation.swift */,
+				OBJ_497 /* ValueBox.swift */,
+				OBJ_498 /* VersionCommand.swift */,
 			);
 			name = SwiftCLI;
 			path = .build/checkouts/SwiftCLI/Sources/SwiftCLI;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_495 /* Products */ = {
+		OBJ_5 /*  */ = {
 			isa = PBXGroup;
 			children = (
-				"Rainbow::Rainbow::Product" /* Rainbow.framework */,
-				"Stencil::Stencil::Product" /* Stencil.framework */,
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_333 /* Tests */,
+				OBJ_342 /* Dependencies */,
+				OBJ_500 /* Products */,
+				OBJ_514 /* Demo */,
+				OBJ_515 /* Docs */,
+				OBJ_516 /* Scripts */,
+				OBJ_517 /* Templates */,
+				OBJ_518 /* LICENSE */,
+				OBJ_519 /* Makefile */,
+				OBJ_520 /* Package.resources */,
+				OBJ_521 /* README.md */,
+				OBJ_522 /* Dangerfile */,
+				OBJ_523 /* Gemfile */,
+				OBJ_524 /* Gemfile.lock */,
+				OBJ_525 /* Brewfile */,
+				OBJ_526 /* Fugen.podspec */,
+			);
+			name = "";
+			sourceTree = "<group>";
+		};
+		OBJ_500 /* Products */ = {
+			isa = PBXGroup;
+			children = (
 				"Fugen::FugenTests::Product" /* FugenTests.xctest */,
 				"DictionaryCoder::DictionaryCoder::Product" /* DictionaryCoder.framework */,
-				"PromiseKit::PromiseKit::Product" /* PromiseKit.framework */,
+				"Stencil::Stencil::Product" /* Stencil.framework */,
 				"StencilSwiftKit::StencilSwiftKit::Product" /* StencilSwiftKit.framework */,
-				"SwiftCLI::SwiftCLI::Product" /* SwiftCLI.framework */,
+				"Fugen::FugenToolsTests::Product" /* FugenToolsTests.xctest */,
+				"Fugen::FugenTools::Product" /* FugenTools.framework */,
+				"Yams::Yams::Product" /* Yams.framework */,
+				"PathKit::PathKit::Product" /* PathKit.framework */,
+				"PromiseKit::PromiseKit::Product" /* PromiseKit.framework */,
 				"Yams::CYaml::Product" /* CYaml.framework */,
 				"Fugen::Fugen::Product" /* Fugen */,
-				"PathKit::PathKit::Product" /* PathKit.framework */,
-				"Yams::Yams::Product" /* Yams.framework */,
-				"Fugen::FugenTools::Product" /* FugenTools.framework */,
-				"Fugen::FugenToolsTests::Product" /* FugenToolsTests.xctest */,
+				"SwiftCLI::SwiftCLI::Product" /* SwiftCLI.framework */,
+				"Rainbow::Rainbow::Product" /* Rainbow.framework */,
 			);
 			name = Products;
 			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		OBJ_5 = {
-			isa = PBXGroup;
-			children = (
-				OBJ_7 /* Sources */,
-				OBJ_328 /* Tests */,
-				OBJ_337 /* Dependencies */,
-				OBJ_495 /* Products */,
-				OBJ_509 /* Demo */,
-				OBJ_510 /* Docs */,
-				OBJ_511 /* Scripts */,
-				OBJ_512 /* Templates */,
-				C042748A24E84B3B00E1605C /* .gitignore */,
-				C042748924E84B3B00E1605C /* .ruby-version */,
-				C042748B24E84B3B00E1605C /* .swift-version */,
-				C042748824E84B3B00E1605C /* .swiftlint.yml */,
-				OBJ_513 /* LICENSE */,
-				OBJ_514 /* Makefile */,
-				OBJ_515 /* Package.resources */,
-				OBJ_6 /* Package.swift */,
-				OBJ_516 /* README.md */,
-				OBJ_517 /* Dangerfile */,
-				OBJ_518 /* Gemfile */,
-				OBJ_520 /* Brewfile */,
-				OBJ_521 /* Fugen.podspec */,
-			);
-			sourceTree = "<group>";
 		};
 		OBJ_57 /* Images */ = {
 			isa = PBXGroup;
@@ -2249,7 +2253,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_8 /* Fugen */,
-				OBJ_221 /* FugenTools */,
+				OBJ_226 /* FugenTools */,
 			);
 			name = Sources;
 			sourceTree = SOURCE_ROOT;
@@ -2257,81 +2261,81 @@
 		OBJ_71 /* ShadowStyle */ = {
 			isa = PBXGroup;
 			children = (
-				C0BE783424E94735004EBBEF /* Shadow.swift */,
-				OBJ_72 /* ShadowStyle.swift */,
-				OBJ_73 /* ShadowStyleNode.swift */,
-				C01B801A24FFF78B0080227E /* ShadowType.swift */,
+				OBJ_72 /* Shadow.swift */,
+				OBJ_73 /* ShadowStyle.swift */,
+				OBJ_74 /* ShadowStyleNode.swift */,
+				OBJ_75 /* ShadowType.swift */,
 			);
 			path = ShadowStyle;
 			sourceTree = "<group>";
 		};
-		OBJ_74 /* TextStyle */ = {
+		OBJ_76 /* TextStyle */ = {
 			isa = PBXGroup;
 			children = (
-				C0BE783624E95650004EBBEF /* TextStyle.swift */,
-				OBJ_77 /* TextStyleNode.swift */,
-				OBJ_76 /* TextStyleColor.swift */,
+				OBJ_77 /* TextStyle.swift */,
+				OBJ_78 /* TextStyleColor.swift */,
+				OBJ_79 /* TextStyleNode.swift */,
 			);
 			path = TextStyle;
-			sourceTree = "<group>";
-		};
-		OBJ_79 /* Providers */ = {
-			isa = PBXGroup;
-			children = (
-				OBJ_80 /* Assets */,
-				OBJ_83 /* ColorStyles */,
-				OBJ_90 /* Configuration */,
-				OBJ_93 /* DataProvider */,
-				OBJ_96 /* FigmaAPI */,
-				OBJ_161 /* FigmaFiles */,
-				OBJ_164 /* FigmaNodes */,
-				OBJ_168 /* Images */,
-				OBJ_182 /* ShadowStyles */,
-				OBJ_186 /* TextStyles */,
-			);
-			path = Providers;
 			sourceTree = "<group>";
 		};
 		OBJ_8 /* Fugen */ = {
 			isa = PBXGroup;
 			children = (
 				OBJ_9 /* Commands */,
+				OBJ_17 /* Dependencies.swift */,
 				OBJ_18 /* Generators */,
 				OBJ_40 /* Models */,
-				OBJ_79 /* Providers */,
-				OBJ_190 /* Render */,
-				OBJ_220 /* main.swift */,
-				OBJ_17 /* Dependencies.swift */,
+				OBJ_81 /* Providers */,
+				OBJ_192 /* Render */,
+				OBJ_225 /* main.swift */,
 			);
 			name = Fugen;
 			path = Sources/Fugen;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_80 /* Assets */ = {
+		OBJ_81 /* Providers */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_81 /* AssetsProvider.swift */,
-				OBJ_82 /* DefaultAssetsProvider.swift */,
+				OBJ_82 /* Assets */,
+				OBJ_85 /* ColorStyles */,
+				OBJ_92 /* Configuration */,
+				OBJ_95 /* DataProvider */,
+				OBJ_98 /* FigmaAPI */,
+				OBJ_163 /* FigmaFiles */,
+				OBJ_166 /* FigmaNodes */,
+				OBJ_170 /* Images */,
+				OBJ_184 /* ShadowStyles */,
+				OBJ_188 /* TextStyles */,
+			);
+			path = Providers;
+			sourceTree = "<group>";
+		};
+		OBJ_82 /* Assets */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_83 /* AssetsProvider.swift */,
+				OBJ_84 /* DefaultAssetsProvider.swift */,
 			);
 			path = Assets;
 			sourceTree = "<group>";
 		};
-		OBJ_83 /* ColorStyles */ = {
+		OBJ_85 /* ColorStyles */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_84 /* Assets */,
-				OBJ_87 /* ColorStylesProvider.swift */,
-				OBJ_88 /* ColorStylesProviderError.swift */,
-				OBJ_89 /* DefaultColorStylesProvider.swift */,
+				OBJ_86 /* Assets */,
+				OBJ_89 /* ColorStylesProvider.swift */,
+				OBJ_90 /* ColorStylesProviderError.swift */,
+				OBJ_91 /* DefaultColorStylesProvider.swift */,
 			);
 			path = ColorStyles;
 			sourceTree = "<group>";
 		};
-		OBJ_84 /* Assets */ = {
+		OBJ_86 /* Assets */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_85 /* ColorStyleAssetsProvider.swift */,
-				OBJ_86 /* DefaultColorStyleAssetsProvider.swift */,
+				OBJ_87 /* ColorStyleAssetsProvider.swift */,
+				OBJ_88 /* DefaultColorStyleAssetsProvider.swift */,
 			);
 			path = Assets;
 			sourceTree = "<group>";
@@ -2350,46 +2354,46 @@
 			path = Commands;
 			sourceTree = "<group>";
 		};
-		OBJ_90 /* Configuration */ = {
+		OBJ_92 /* Configuration */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_91 /* ConfigurationProvider.swift */,
-				OBJ_92 /* DefaultConfigurationProvider.swift */,
+				OBJ_93 /* ConfigurationProvider.swift */,
+				OBJ_94 /* DefaultConfigurationProvider.swift */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
 		};
-		OBJ_93 /* DataProvider */ = {
+		OBJ_95 /* DataProvider */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_94 /* DataProvider.swift */,
-				OBJ_95 /* DefaultDataProvider.swift */,
+				OBJ_96 /* DataProvider.swift */,
+				OBJ_97 /* DefaultDataProvider.swift */,
 			);
 			path = DataProvider;
 			sourceTree = "<group>";
 		};
-		OBJ_96 /* FigmaAPI */ = {
+		OBJ_98 /* FigmaAPI */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_97 /* DTOs */,
-				OBJ_156 /* Routes */,
-				OBJ_149 /* DefaultFigmaAPIProvider.swift */,
-				OBJ_150 /* FigmaAPIEmptyParameters.swift */,
-				OBJ_151 /* FigmaAPIEmptyResponse.swift */,
-				OBJ_152 /* FigmaAPIProvider.swift */,
-				OBJ_153 /* FigmaAPIRoute.swift */,
-				OBJ_154 /* FigmaAPIVersion.swift */,
-				OBJ_155 /* FigmaHTTPService.swift */,
+				OBJ_99 /* DTOs */,
+				OBJ_151 /* DefaultFigmaAPIProvider.swift */,
+				OBJ_152 /* FigmaAPIEmptyParameters.swift */,
+				OBJ_153 /* FigmaAPIEmptyResponse.swift */,
+				OBJ_154 /* FigmaAPIProvider.swift */,
+				OBJ_155 /* FigmaAPIRoute.swift */,
+				OBJ_156 /* FigmaAPIVersion.swift */,
+				OBJ_157 /* FigmaHTTPService.swift */,
+				OBJ_158 /* Routes */,
 			);
 			path = FigmaAPI;
 			sourceTree = "<group>";
 		};
-		OBJ_97 /* DTOs */ = {
+		OBJ_99 /* DTOs */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_100 /* File */,
-				OBJ_98 /* FigmaError.swift */,
-				OBJ_99 /* FigmaImages.swift */,
+				OBJ_100 /* FigmaError.swift */,
+				OBJ_101 /* FigmaImages.swift */,
+				OBJ_102 /* File */,
 			);
 			path = DTOs;
 			sourceTree = "<group>";
@@ -2397,12 +2401,12 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		OBJ_533 /* Headers */ = {
+		OBJ_538 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_534 /* CYaml.h in Headers */,
-				OBJ_535 /* yaml.h in Headers */,
+				OBJ_539 /* CYaml.h in Headers */,
+				OBJ_540 /* yaml.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2411,10 +2415,10 @@
 /* Begin PBXNativeTarget section */
 		"DictionaryCoder::DictionaryCoder" /* DictionaryCoder */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_538 /* Build configuration list for PBXNativeTarget "DictionaryCoder" */;
+			buildConfigurationList = OBJ_543 /* Build configuration list for PBXNativeTarget "DictionaryCoder" */;
 			buildPhases = (
-				OBJ_541 /* Sources */,
-				OBJ_568 /* Frameworks */,
+				OBJ_546 /* Sources */,
+				OBJ_573 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2427,9 +2431,9 @@
 		};
 		"DictionaryCoder::SwiftPMPackageDescription" /* DictionaryCoderPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_570 /* Build configuration list for PBXNativeTarget "DictionaryCoderPackageDescription" */;
+			buildConfigurationList = OBJ_575 /* Build configuration list for PBXNativeTarget "DictionaryCoderPackageDescription" */;
 			buildPhases = (
-				OBJ_573 /* Sources */,
+				OBJ_578 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -2441,25 +2445,24 @@
 		};
 		"Fugen::Fugen" /* Fugen */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_576 /* Build configuration list for PBXNativeTarget "Fugen" */;
+			buildConfigurationList = OBJ_581 /* Build configuration list for PBXNativeTarget "Fugen" */;
 			buildPhases = (
-				OBJ_579 /* Sources */,
-				OBJ_754 /* Frameworks */,
-				C042748F24E84BA200E1605C /* SwiftLint */,
+				OBJ_584 /* Sources */,
+				OBJ_763 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_765 /* PBXTargetDependency */,
-				OBJ_766 /* PBXTargetDependency */,
-				OBJ_768 /* PBXTargetDependency */,
-				OBJ_770 /* PBXTargetDependency */,
-				OBJ_772 /* PBXTargetDependency */,
 				OBJ_774 /* PBXTargetDependency */,
 				OBJ_775 /* PBXTargetDependency */,
 				OBJ_777 /* PBXTargetDependency */,
 				OBJ_779 /* PBXTargetDependency */,
 				OBJ_781 /* PBXTargetDependency */,
+				OBJ_783 /* PBXTargetDependency */,
+				OBJ_784 /* PBXTargetDependency */,
+				OBJ_786 /* PBXTargetDependency */,
+				OBJ_788 /* PBXTargetDependency */,
+				OBJ_790 /* PBXTargetDependency */,
 			);
 			name = Fugen;
 			productName = Fugen;
@@ -2468,25 +2471,25 @@
 		};
 		"Fugen::FugenTests" /* FugenTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_797 /* Build configuration list for PBXNativeTarget "FugenTests" */;
+			buildConfigurationList = OBJ_806 /* Build configuration list for PBXNativeTarget "FugenTests" */;
 			buildPhases = (
-				OBJ_800 /* Sources */,
-				OBJ_803 /* Frameworks */,
+				OBJ_809 /* Sources */,
+				OBJ_812 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_814 /* PBXTargetDependency */,
-				OBJ_815 /* PBXTargetDependency */,
-				OBJ_816 /* PBXTargetDependency */,
-				OBJ_817 /* PBXTargetDependency */,
-				OBJ_818 /* PBXTargetDependency */,
-				OBJ_819 /* PBXTargetDependency */,
-				OBJ_820 /* PBXTargetDependency */,
-				OBJ_821 /* PBXTargetDependency */,
-				OBJ_822 /* PBXTargetDependency */,
 				OBJ_823 /* PBXTargetDependency */,
 				OBJ_824 /* PBXTargetDependency */,
+				OBJ_825 /* PBXTargetDependency */,
+				OBJ_826 /* PBXTargetDependency */,
+				OBJ_827 /* PBXTargetDependency */,
+				OBJ_828 /* PBXTargetDependency */,
+				OBJ_829 /* PBXTargetDependency */,
+				OBJ_830 /* PBXTargetDependency */,
+				OBJ_831 /* PBXTargetDependency */,
+				OBJ_832 /* PBXTargetDependency */,
+				OBJ_833 /* PBXTargetDependency */,
 			);
 			name = FugenTests;
 			productName = FugenTests;
@@ -2495,17 +2498,17 @@
 		};
 		"Fugen::FugenTools" /* FugenTools */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_825 /* Build configuration list for PBXNativeTarget "FugenTools" */;
+			buildConfigurationList = OBJ_834 /* Build configuration list for PBXNativeTarget "FugenTools" */;
 			buildPhases = (
-				OBJ_828 /* Sources */,
-				OBJ_924 /* Frameworks */,
+				OBJ_837 /* Sources */,
+				OBJ_933 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_928 /* PBXTargetDependency */,
-				OBJ_929 /* PBXTargetDependency */,
-				OBJ_930 /* PBXTargetDependency */,
+				OBJ_937 /* PBXTargetDependency */,
+				OBJ_938 /* PBXTargetDependency */,
+				OBJ_939 /* PBXTargetDependency */,
 			);
 			name = FugenTools;
 			productName = FugenTools;
@@ -2514,18 +2517,18 @@
 		};
 		"Fugen::FugenToolsTests" /* FugenToolsTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_931 /* Build configuration list for PBXNativeTarget "FugenToolsTests" */;
+			buildConfigurationList = OBJ_940 /* Build configuration list for PBXNativeTarget "FugenToolsTests" */;
 			buildPhases = (
-				OBJ_934 /* Sources */,
-				OBJ_937 /* Frameworks */,
+				OBJ_943 /* Sources */,
+				OBJ_946 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_942 /* PBXTargetDependency */,
-				OBJ_943 /* PBXTargetDependency */,
-				OBJ_944 /* PBXTargetDependency */,
-				OBJ_945 /* PBXTargetDependency */,
+				OBJ_951 /* PBXTargetDependency */,
+				OBJ_952 /* PBXTargetDependency */,
+				OBJ_953 /* PBXTargetDependency */,
+				OBJ_954 /* PBXTargetDependency */,
 			);
 			name = FugenToolsTests;
 			productName = FugenToolsTests;
@@ -2534,9 +2537,9 @@
 		};
 		"Fugen::SwiftPMPackageDescription" /* FugenPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_784 /* Build configuration list for PBXNativeTarget "FugenPackageDescription" */;
+			buildConfigurationList = OBJ_793 /* Build configuration list for PBXNativeTarget "FugenPackageDescription" */;
 			buildPhases = (
-				OBJ_787 /* Sources */,
+				OBJ_796 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -2548,10 +2551,10 @@
 		};
 		"PathKit::PathKit" /* PathKit */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_946 /* Build configuration list for PBXNativeTarget "PathKit" */;
+			buildConfigurationList = OBJ_955 /* Build configuration list for PBXNativeTarget "PathKit" */;
 			buildPhases = (
-				OBJ_949 /* Sources */,
-				OBJ_951 /* Frameworks */,
+				OBJ_958 /* Sources */,
+				OBJ_960 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2564,9 +2567,9 @@
 		};
 		"PathKit::SwiftPMPackageDescription" /* PathKitPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_953 /* Build configuration list for PBXNativeTarget "PathKitPackageDescription" */;
+			buildConfigurationList = OBJ_962 /* Build configuration list for PBXNativeTarget "PathKitPackageDescription" */;
 			buildPhases = (
-				OBJ_956 /* Sources */,
+				OBJ_965 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -2578,10 +2581,10 @@
 		};
 		"PromiseKit::PromiseKit" /* PromiseKit */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_958 /* Build configuration list for PBXNativeTarget "PromiseKit" */;
+			buildConfigurationList = OBJ_967 /* Build configuration list for PBXNativeTarget "PromiseKit" */;
 			buildPhases = (
-				OBJ_961 /* Sources */,
-				OBJ_977 /* Frameworks */,
+				OBJ_970 /* Sources */,
+				OBJ_986 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2594,9 +2597,9 @@
 		};
 		"PromiseKit::SwiftPMPackageDescription" /* PromiseKitPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_979 /* Build configuration list for PBXNativeTarget "PromiseKitPackageDescription" */;
+			buildConfigurationList = OBJ_988 /* Build configuration list for PBXNativeTarget "PromiseKitPackageDescription" */;
 			buildPhases = (
-				OBJ_982 /* Sources */,
+				OBJ_991 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -2608,10 +2611,10 @@
 		};
 		"Rainbow::Rainbow" /* Rainbow */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_984 /* Build configuration list for PBXNativeTarget "Rainbow" */;
+			buildConfigurationList = OBJ_993 /* Build configuration list for PBXNativeTarget "Rainbow" */;
 			buildPhases = (
-				OBJ_987 /* Sources */,
-				OBJ_999 /* Frameworks */,
+				OBJ_996 /* Sources */,
+				OBJ_1008 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2624,9 +2627,9 @@
 		};
 		"Rainbow::SwiftPMPackageDescription" /* RainbowPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1001 /* Build configuration list for PBXNativeTarget "RainbowPackageDescription" */;
+			buildConfigurationList = OBJ_1010 /* Build configuration list for PBXNativeTarget "RainbowPackageDescription" */;
 			buildPhases = (
-				OBJ_1004 /* Sources */,
+				OBJ_1013 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -2638,15 +2641,15 @@
 		};
 		"Stencil::Stencil" /* Stencil */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1006 /* Build configuration list for PBXNativeTarget "Stencil" */;
+			buildConfigurationList = OBJ_1015 /* Build configuration list for PBXNativeTarget "Stencil" */;
 			buildPhases = (
-				OBJ_1009 /* Sources */,
-				OBJ_1030 /* Frameworks */,
+				OBJ_1018 /* Sources */,
+				OBJ_1039 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_1032 /* PBXTargetDependency */,
+				OBJ_1041 /* PBXTargetDependency */,
 			);
 			name = Stencil;
 			productName = Stencil;
@@ -2655,9 +2658,9 @@
 		};
 		"Stencil::SwiftPMPackageDescription" /* StencilPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1034 /* Build configuration list for PBXNativeTarget "StencilPackageDescription" */;
+			buildConfigurationList = OBJ_1043 /* Build configuration list for PBXNativeTarget "StencilPackageDescription" */;
 			buildPhases = (
-				OBJ_1037 /* Sources */,
+				OBJ_1046 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -2669,16 +2672,16 @@
 		};
 		"StencilSwiftKit::StencilSwiftKit" /* StencilSwiftKit */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1039 /* Build configuration list for PBXNativeTarget "StencilSwiftKit" */;
+			buildConfigurationList = OBJ_1048 /* Build configuration list for PBXNativeTarget "StencilSwiftKit" */;
 			buildPhases = (
-				OBJ_1042 /* Sources */,
-				OBJ_1054 /* Frameworks */,
+				OBJ_1051 /* Sources */,
+				OBJ_1063 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_1057 /* PBXTargetDependency */,
-				OBJ_1058 /* PBXTargetDependency */,
+				OBJ_1066 /* PBXTargetDependency */,
+				OBJ_1067 /* PBXTargetDependency */,
 			);
 			name = StencilSwiftKit;
 			productName = StencilSwiftKit;
@@ -2687,9 +2690,9 @@
 		};
 		"StencilSwiftKit::SwiftPMPackageDescription" /* StencilSwiftKitPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1060 /* Build configuration list for PBXNativeTarget "StencilSwiftKitPackageDescription" */;
+			buildConfigurationList = OBJ_1069 /* Build configuration list for PBXNativeTarget "StencilSwiftKitPackageDescription" */;
 			buildPhases = (
-				OBJ_1063 /* Sources */,
+				OBJ_1072 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -2701,10 +2704,10 @@
 		};
 		"SwiftCLI::SwiftCLI" /* SwiftCLI */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1065 /* Build configuration list for PBXNativeTarget "SwiftCLI" */;
+			buildConfigurationList = OBJ_1074 /* Build configuration list for PBXNativeTarget "SwiftCLI" */;
 			buildPhases = (
-				OBJ_1068 /* Sources */,
-				OBJ_1091 /* Frameworks */,
+				OBJ_1077 /* Sources */,
+				OBJ_1100 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2717,9 +2720,9 @@
 		};
 		"SwiftCLI::SwiftPMPackageDescription" /* SwiftCLIPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1093 /* Build configuration list for PBXNativeTarget "SwiftCLIPackageDescription" */;
+			buildConfigurationList = OBJ_1102 /* Build configuration list for PBXNativeTarget "SwiftCLIPackageDescription" */;
 			buildPhases = (
-				OBJ_1096 /* Sources */,
+				OBJ_1105 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -2731,11 +2734,11 @@
 		};
 		"Yams::CYaml" /* CYaml */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_523 /* Build configuration list for PBXNativeTarget "CYaml" */;
+			buildConfigurationList = OBJ_528 /* Build configuration list for PBXNativeTarget "CYaml" */;
 			buildPhases = (
-				OBJ_526 /* Sources */,
-				OBJ_533 /* Headers */,
-				OBJ_536 /* Frameworks */,
+				OBJ_531 /* Sources */,
+				OBJ_538 /* Headers */,
+				OBJ_541 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2748,9 +2751,9 @@
 		};
 		"Yams::SwiftPMPackageDescription" /* YamsPackageDescription */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1122 /* Build configuration list for PBXNativeTarget "YamsPackageDescription" */;
+			buildConfigurationList = OBJ_1131 /* Build configuration list for PBXNativeTarget "YamsPackageDescription" */;
 			buildPhases = (
-				OBJ_1125 /* Sources */,
+				OBJ_1134 /* Sources */,
 			);
 			buildRules = (
 			);
@@ -2762,15 +2765,15 @@
 		};
 		"Yams::Yams" /* Yams */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = OBJ_1098 /* Build configuration list for PBXNativeTarget "Yams" */;
+			buildConfigurationList = OBJ_1107 /* Build configuration list for PBXNativeTarget "Yams" */;
 			buildPhases = (
-				OBJ_1101 /* Sources */,
-				OBJ_1118 /* Frameworks */,
+				OBJ_1110 /* Sources */,
+				OBJ_1127 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				OBJ_1120 /* PBXTargetDependency */,
+				OBJ_1129 /* PBXTargetDependency */,
 			);
 			name = Yams;
 			productName = Yams;
@@ -2785,11 +2788,6 @@
 			attributes = {
 				LastSwiftMigration = 9999;
 				LastUpgradeCheck = 9999;
-				TargetAttributes = {
-					"Yams::CYaml" = {
-						LastSwiftMigration = 1150;
-					};
-				};
 			};
 			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "Fugen" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -2798,8 +2796,8 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5;
-			productRefGroup = OBJ_495 /* Products */;
+			mainGroup = OBJ_5 /*  */;
+			productRefGroup = OBJ_500 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -2831,796 +2829,780 @@
 		};
 /* End PBXProject section */
 
-/* Begin PBXShellScriptBuildPhase section */
-		C042748F24E84BA200E1605C /* SwiftLint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			name = SwiftLint;
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "sh Scripts/swiftlint.sh\n";
-		};
-/* End PBXShellScriptBuildPhase section */
-
 /* Begin PBXSourcesBuildPhase section */
-		OBJ_1004 /* Sources */ = {
+		OBJ_1013 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_1005 /* Package.swift in Sources */,
+				OBJ_1014 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_1009 /* Sources */ = {
+		OBJ_1018 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_1010 /* Context.swift in Sources */,
-				OBJ_1011 /* Environment.swift in Sources */,
-				OBJ_1012 /* Errors.swift in Sources */,
-				OBJ_1013 /* Expression.swift in Sources */,
-				OBJ_1014 /* Extension.swift in Sources */,
-				OBJ_1015 /* FilterTag.swift in Sources */,
-				OBJ_1016 /* Filters.swift in Sources */,
-				OBJ_1017 /* ForTag.swift in Sources */,
-				OBJ_1018 /* IfTag.swift in Sources */,
-				OBJ_1019 /* Include.swift in Sources */,
-				OBJ_1020 /* Inheritence.swift in Sources */,
-				OBJ_1021 /* KeyPath.swift in Sources */,
-				OBJ_1022 /* Lexer.swift in Sources */,
-				OBJ_1023 /* Loader.swift in Sources */,
-				OBJ_1024 /* Node.swift in Sources */,
-				OBJ_1025 /* NowTag.swift in Sources */,
-				OBJ_1026 /* Parser.swift in Sources */,
-				OBJ_1027 /* Template.swift in Sources */,
-				OBJ_1028 /* Tokenizer.swift in Sources */,
-				OBJ_1029 /* Variable.swift in Sources */,
+				OBJ_1019 /* Context.swift in Sources */,
+				OBJ_1020 /* Environment.swift in Sources */,
+				OBJ_1021 /* Errors.swift in Sources */,
+				OBJ_1022 /* Expression.swift in Sources */,
+				OBJ_1023 /* Extension.swift in Sources */,
+				OBJ_1024 /* FilterTag.swift in Sources */,
+				OBJ_1025 /* Filters.swift in Sources */,
+				OBJ_1026 /* ForTag.swift in Sources */,
+				OBJ_1027 /* IfTag.swift in Sources */,
+				OBJ_1028 /* Include.swift in Sources */,
+				OBJ_1029 /* Inheritence.swift in Sources */,
+				OBJ_1030 /* KeyPath.swift in Sources */,
+				OBJ_1031 /* Lexer.swift in Sources */,
+				OBJ_1032 /* Loader.swift in Sources */,
+				OBJ_1033 /* Node.swift in Sources */,
+				OBJ_1034 /* NowTag.swift in Sources */,
+				OBJ_1035 /* Parser.swift in Sources */,
+				OBJ_1036 /* Template.swift in Sources */,
+				OBJ_1037 /* Tokenizer.swift in Sources */,
+				OBJ_1038 /* Variable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_1037 /* Sources */ = {
+		OBJ_1046 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_1038 /* Package.swift in Sources */,
+				OBJ_1047 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_1042 /* Sources */ = {
+		OBJ_1051 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_1043 /* CallMacroNodes.swift in Sources */,
-				OBJ_1044 /* Context.swift in Sources */,
-				OBJ_1045 /* Environment.swift in Sources */,
-				OBJ_1046 /* Filters+Numbers.swift in Sources */,
-				OBJ_1047 /* Filters+Strings.swift in Sources */,
-				OBJ_1048 /* Filters.swift in Sources */,
-				OBJ_1049 /* MapNode.swift in Sources */,
-				OBJ_1050 /* Parameters.swift in Sources */,
-				OBJ_1051 /* SetNode.swift in Sources */,
-				OBJ_1052 /* StencilSwiftTemplate.swift in Sources */,
-				OBJ_1053 /* SwiftIdentifier.swift in Sources */,
+				OBJ_1052 /* CallMacroNodes.swift in Sources */,
+				OBJ_1053 /* Context.swift in Sources */,
+				OBJ_1054 /* Environment.swift in Sources */,
+				OBJ_1055 /* Filters+Numbers.swift in Sources */,
+				OBJ_1056 /* Filters+Strings.swift in Sources */,
+				OBJ_1057 /* Filters.swift in Sources */,
+				OBJ_1058 /* MapNode.swift in Sources */,
+				OBJ_1059 /* Parameters.swift in Sources */,
+				OBJ_1060 /* SetNode.swift in Sources */,
+				OBJ_1061 /* StencilSwiftTemplate.swift in Sources */,
+				OBJ_1062 /* SwiftIdentifier.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_1063 /* Sources */ = {
+		OBJ_1072 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_1064 /* Package.swift in Sources */,
+				OBJ_1073 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_1068 /* Sources */ = {
+		OBJ_1077 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_1069 /* ArgumentList.swift in Sources */,
-				OBJ_1070 /* ArgumentListManipulator.swift in Sources */,
-				OBJ_1071 /* CLI.swift in Sources */,
-				OBJ_1072 /* Command.swift in Sources */,
-				OBJ_1073 /* Compatibility.swift in Sources */,
-				OBJ_1074 /* CompletionGenerator.swift in Sources */,
-				OBJ_1075 /* Error.swift in Sources */,
-				OBJ_1076 /* HelpCommand.swift in Sources */,
-				OBJ_1077 /* HelpMessageGenerator.swift in Sources */,
-				OBJ_1078 /* Input.swift in Sources */,
-				OBJ_1079 /* Option.swift in Sources */,
-				OBJ_1080 /* OptionGroup.swift in Sources */,
-				OBJ_1081 /* OptionRegistry.swift in Sources */,
-				OBJ_1082 /* Parameter.swift in Sources */,
-				OBJ_1083 /* Parser.swift in Sources */,
-				OBJ_1084 /* Path.swift in Sources */,
-				OBJ_1085 /* Stream.swift in Sources */,
-				OBJ_1086 /* Task.swift in Sources */,
-				OBJ_1087 /* Term.swift in Sources */,
-				OBJ_1088 /* Validation.swift in Sources */,
-				OBJ_1089 /* ValueBox.swift in Sources */,
-				OBJ_1090 /* VersionCommand.swift in Sources */,
+				OBJ_1078 /* ArgumentList.swift in Sources */,
+				OBJ_1079 /* ArgumentListManipulator.swift in Sources */,
+				OBJ_1080 /* CLI.swift in Sources */,
+				OBJ_1081 /* Command.swift in Sources */,
+				OBJ_1082 /* Compatibility.swift in Sources */,
+				OBJ_1083 /* CompletionGenerator.swift in Sources */,
+				OBJ_1084 /* Error.swift in Sources */,
+				OBJ_1085 /* HelpCommand.swift in Sources */,
+				OBJ_1086 /* HelpMessageGenerator.swift in Sources */,
+				OBJ_1087 /* Input.swift in Sources */,
+				OBJ_1088 /* Option.swift in Sources */,
+				OBJ_1089 /* OptionGroup.swift in Sources */,
+				OBJ_1090 /* OptionRegistry.swift in Sources */,
+				OBJ_1091 /* Parameter.swift in Sources */,
+				OBJ_1092 /* Parser.swift in Sources */,
+				OBJ_1093 /* Path.swift in Sources */,
+				OBJ_1094 /* Stream.swift in Sources */,
+				OBJ_1095 /* Task.swift in Sources */,
+				OBJ_1096 /* Term.swift in Sources */,
+				OBJ_1097 /* Validation.swift in Sources */,
+				OBJ_1098 /* ValueBox.swift in Sources */,
+				OBJ_1099 /* VersionCommand.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_1096 /* Sources */ = {
+		OBJ_1105 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_1097 /* Package.swift in Sources */,
+				OBJ_1106 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_1101 /* Sources */ = {
+		OBJ_1110 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_1102 /* Constructor.swift in Sources */,
-				OBJ_1103 /* Decoder.swift in Sources */,
-				OBJ_1104 /* Emitter.swift in Sources */,
-				OBJ_1105 /* Encoder.swift in Sources */,
-				OBJ_1106 /* Mark.swift in Sources */,
-				OBJ_1107 /* Node.Mapping.swift in Sources */,
-				OBJ_1108 /* Node.Scalar.swift in Sources */,
-				OBJ_1109 /* Node.Sequence.swift in Sources */,
-				OBJ_1110 /* Node.swift in Sources */,
-				OBJ_1111 /* Parser.swift in Sources */,
-				OBJ_1112 /* Representer.swift in Sources */,
-				OBJ_1113 /* Resolver.swift in Sources */,
-				OBJ_1114 /* String+Yams.swift in Sources */,
-				OBJ_1115 /* Tag.swift in Sources */,
-				OBJ_1116 /* YamlError.swift in Sources */,
-				OBJ_1117 /* shim.swift in Sources */,
+				OBJ_1111 /* Constructor.swift in Sources */,
+				OBJ_1112 /* Decoder.swift in Sources */,
+				OBJ_1113 /* Emitter.swift in Sources */,
+				OBJ_1114 /* Encoder.swift in Sources */,
+				OBJ_1115 /* Mark.swift in Sources */,
+				OBJ_1116 /* Node.Mapping.swift in Sources */,
+				OBJ_1117 /* Node.Scalar.swift in Sources */,
+				OBJ_1118 /* Node.Sequence.swift in Sources */,
+				OBJ_1119 /* Node.swift in Sources */,
+				OBJ_1120 /* Parser.swift in Sources */,
+				OBJ_1121 /* Representer.swift in Sources */,
+				OBJ_1122 /* Resolver.swift in Sources */,
+				OBJ_1123 /* String+Yams.swift in Sources */,
+				OBJ_1124 /* Tag.swift in Sources */,
+				OBJ_1125 /* YamlError.swift in Sources */,
+				OBJ_1126 /* shim.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_1125 /* Sources */ = {
+		OBJ_1134 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_1126 /* Package.swift in Sources */,
+				OBJ_1135 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_526 /* Sources */ = {
+		OBJ_531 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_527 /* api.c in Sources */,
-				OBJ_528 /* emitter.c in Sources */,
-				OBJ_529 /* parser.c in Sources */,
-				OBJ_530 /* reader.c in Sources */,
-				OBJ_531 /* scanner.c in Sources */,
-				OBJ_532 /* writer.c in Sources */,
+				OBJ_532 /* api.c in Sources */,
+				OBJ_533 /* emitter.c in Sources */,
+				OBJ_534 /* parser.c in Sources */,
+				OBJ_535 /* reader.c in Sources */,
+				OBJ_536 /* scanner.c in Sources */,
+				OBJ_537 /* writer.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_541 /* Sources */ = {
+		OBJ_546 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_542 /* DictionaryComponentDecoder.swift in Sources */,
-				OBJ_543 /* DictionaryDecoder.swift in Sources */,
-				OBJ_544 /* DictionaryDecodingOptions.swift in Sources */,
-				OBJ_545 /* DictionaryKeyedDecodingContainer.swift in Sources */,
-				OBJ_546 /* DictionarySingleValueDecodingContainer.swift in Sources */,
-				OBJ_547 /* DictionaryUnkeyedDecodingContainer.swift in Sources */,
-				OBJ_548 /* DictionaryDataDecodingStrategy.swift in Sources */,
-				OBJ_549 /* DictionaryDateDecodingStrategy.swift in Sources */,
-				OBJ_550 /* DictionaryKeyDecodingStrategy.swift in Sources */,
-				OBJ_551 /* DictionaryNonConformingFloatDecodingStrategy.swift in Sources */,
-				OBJ_552 /* DictionaryAnyKeyedEncodingContainer.swift in Sources */,
-				OBJ_553 /* DictionaryComponent.swift in Sources */,
-				OBJ_554 /* DictionaryComponentContainer.swift in Sources */,
-				OBJ_555 /* DictionaryComponentEncoder.swift in Sources */,
-				OBJ_556 /* DictionaryEncoder.swift in Sources */,
-				OBJ_557 /* DictionaryEncodingOptions.swift in Sources */,
-				OBJ_558 /* DictionaryKeyedEncodingContainer.swift in Sources */,
-				OBJ_559 /* DictionarySingleValueEncodingContainer.swift in Sources */,
-				OBJ_560 /* DictionaryUnkeyedEncodingContainer.swift in Sources */,
-				OBJ_561 /* DictionaryDataEncodingStrategy.swift in Sources */,
-				OBJ_562 /* DictionaryDateEncodingStrategy.swift in Sources */,
-				OBJ_563 /* DictionaryKeyEncodingStrategy.swift in Sources */,
-				OBJ_564 /* DictionaryNonConformingFloatEncodingStrategy.swift in Sources */,
-				OBJ_565 /* AnyCodingKey.swift in Sources */,
-				OBJ_566 /* Optional+Extensions.swift in Sources */,
-				OBJ_567 /* RangeReplaceableCollection+Extensions.swift in Sources */,
+				OBJ_547 /* DictionaryComponentDecoder.swift in Sources */,
+				OBJ_548 /* DictionaryDecoder.swift in Sources */,
+				OBJ_549 /* DictionaryDecodingOptions.swift in Sources */,
+				OBJ_550 /* DictionaryKeyedDecodingContainer.swift in Sources */,
+				OBJ_551 /* DictionarySingleValueDecodingContainer.swift in Sources */,
+				OBJ_552 /* DictionaryUnkeyedDecodingContainer.swift in Sources */,
+				OBJ_553 /* DictionaryDataDecodingStrategy.swift in Sources */,
+				OBJ_554 /* DictionaryDateDecodingStrategy.swift in Sources */,
+				OBJ_555 /* DictionaryKeyDecodingStrategy.swift in Sources */,
+				OBJ_556 /* DictionaryNonConformingFloatDecodingStrategy.swift in Sources */,
+				OBJ_557 /* DictionaryAnyKeyedEncodingContainer.swift in Sources */,
+				OBJ_558 /* DictionaryComponent.swift in Sources */,
+				OBJ_559 /* DictionaryComponentContainer.swift in Sources */,
+				OBJ_560 /* DictionaryComponentEncoder.swift in Sources */,
+				OBJ_561 /* DictionaryEncoder.swift in Sources */,
+				OBJ_562 /* DictionaryEncodingOptions.swift in Sources */,
+				OBJ_563 /* DictionaryKeyedEncodingContainer.swift in Sources */,
+				OBJ_564 /* DictionarySingleValueEncodingContainer.swift in Sources */,
+				OBJ_565 /* DictionaryUnkeyedEncodingContainer.swift in Sources */,
+				OBJ_566 /* DictionaryDataEncodingStrategy.swift in Sources */,
+				OBJ_567 /* DictionaryDateEncodingStrategy.swift in Sources */,
+				OBJ_568 /* DictionaryKeyEncodingStrategy.swift in Sources */,
+				OBJ_569 /* DictionaryNonConformingFloatEncodingStrategy.swift in Sources */,
+				OBJ_570 /* AnyCodingKey.swift in Sources */,
+				OBJ_571 /* Optional+Extensions.swift in Sources */,
+				OBJ_572 /* RangeReplaceableCollection+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_573 /* Sources */ = {
+		OBJ_578 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_574 /* Package.swift in Sources */,
+				OBJ_579 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_579 /* Sources */ = {
+		OBJ_584 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_580 /* AsyncExecutableCommand.swift in Sources */,
-				OBJ_581 /* ColorStylesCommand.swift in Sources */,
-				OBJ_582 /* GenerateCommand.swift in Sources */,
-				OBJ_583 /* GenerationConfigurableCommand.swift in Sources */,
-				OBJ_584 /* ImagesCommand.swift in Sources */,
-				OBJ_585 /* ShadowStylesCommand.swift in Sources */,
-				OBJ_586 /* TextStylesCommand.swift in Sources */,
-				OBJ_587 /* Dependencies.swift in Sources */,
-				OBJ_588 /* ColorStylesContext.swift in Sources */,
-				OBJ_589 /* ColorStylesGenerator.swift in Sources */,
-				C0BE783724E95650004EBBEF /* TextStyle.swift in Sources */,
-				OBJ_590 /* DefaultColorStylesGenerator.swift in Sources */,
-				OBJ_591 /* GenerationParametersError.swift in Sources */,
-				C0BE783524E94735004EBBEF /* Shadow.swift in Sources */,
-				OBJ_592 /* GenerationParametersResolving.swift in Sources */,
-				OBJ_593 /* DefaultImagesGenerator.swift in Sources */,
-				OBJ_594 /* ImagesContext.swift in Sources */,
-				OBJ_595 /* ImagesGenerator.swift in Sources */,
-				OBJ_596 /* DefaultLibraryGenerator.swift in Sources */,
-				OBJ_597 /* LibraryGenerator.swift in Sources */,
-				OBJ_598 /* DefaultShadowStylesGenerator.swift in Sources */,
-				OBJ_599 /* ShadowStylesContext.swift in Sources */,
-				OBJ_600 /* ShadowStylesGenerator.swift in Sources */,
-				OBJ_601 /* DefaultTextStylesGenerator.swift in Sources */,
-				OBJ_602 /* TextStylesContext.swift in Sources */,
-				OBJ_603 /* TextStylesGenerator.swift in Sources */,
-				OBJ_604 /* Color.swift in Sources */,
-				C0BE783E24E9B2E8004EBBEF /* StencilVectorInfoFilter.swift in Sources */,
-				OBJ_605 /* ColorStyle.swift in Sources */,
-				OBJ_606 /* ColorStyleAsset.swift in Sources */,
-				OBJ_607 /* ColorStyleNode.swift in Sources */,
-				OBJ_608 /* AccessTokenConfiguration.swift in Sources */,
-				OBJ_609 /* BaseConfiguration.swift in Sources */,
-				C01B801C24FFF7D00080227E /* ShadowType.swift in Sources */,
-				OBJ_610 /* ColorStylesConfiguration.swift in Sources */,
-				OBJ_611 /* Configuration.swift in Sources */,
-				OBJ_612 /* FileConfiguration.swift in Sources */,
-				OBJ_613 /* GenerationConfiguration.swift in Sources */,
-				OBJ_614 /* ImagesConfiguration.swift in Sources */,
-				OBJ_615 /* ShadowStylesConfiguration.swift in Sources */,
-				OBJ_616 /* TextStylesConfiguration.swift in Sources */,
-				OBJ_617 /* Font.swift in Sources */,
-				OBJ_618 /* Image.swift in Sources */,
-				OBJ_619 /* ImageAsset.swift in Sources */,
-				OBJ_620 /* ImageFormat.swift in Sources */,
-				OBJ_621 /* ImageNode.swift in Sources */,
-				OBJ_622 /* ImageRenderedNode.swift in Sources */,
-				OBJ_623 /* ImageResource.swift in Sources */,
-				OBJ_624 /* ImageScale.swift in Sources */,
-				OBJ_625 /* FileParameters.swift in Sources */,
-				OBJ_626 /* GenerationParameters.swift in Sources */,
-				OBJ_627 /* ImagesParameters.swift in Sources */,
-				OBJ_628 /* NodesParameters.swift in Sources */,
-				OBJ_629 /* RenderParameters.swift in Sources */,
-				OBJ_630 /* ShadowStyle.swift in Sources */,
-				OBJ_631 /* ShadowStyleNode.swift in Sources */,
-				OBJ_633 /* TextStyleColor.swift in Sources */,
-				OBJ_634 /* TextStyleNode.swift in Sources */,
-				OBJ_635 /* Vector.swift in Sources */,
-				OBJ_636 /* AssetsProvider.swift in Sources */,
-				OBJ_637 /* DefaultAssetsProvider.swift in Sources */,
-				OBJ_638 /* ColorStyleAssetsProvider.swift in Sources */,
-				OBJ_639 /* DefaultColorStyleAssetsProvider.swift in Sources */,
-				OBJ_640 /* ColorStylesProvider.swift in Sources */,
-				OBJ_641 /* ColorStylesProviderError.swift in Sources */,
-				OBJ_642 /* DefaultColorStylesProvider.swift in Sources */,
-				OBJ_643 /* ConfigurationProvider.swift in Sources */,
-				OBJ_644 /* DefaultConfigurationProvider.swift in Sources */,
-				OBJ_645 /* DataProvider.swift in Sources */,
-				OBJ_646 /* DefaultDataProvider.swift in Sources */,
-				OBJ_647 /* FigmaError.swift in Sources */,
-				OBJ_648 /* FigmaImages.swift in Sources */,
-				OBJ_649 /* FigmaBlendMode.swift in Sources */,
-				OBJ_650 /* FigmaBooleanOperationType.swift in Sources */,
-				OBJ_651 /* FigmaColor.swift in Sources */,
-				OBJ_652 /* FigmaColorStop.swift in Sources */,
-				OBJ_653 /* FigmaComponent.swift in Sources */,
-				OBJ_654 /* FigmaConstraint.swift in Sources */,
-				OBJ_655 /* FigmaConstraintType.swift in Sources */,
-				OBJ_656 /* FigmaEasingType.swift in Sources */,
-				OBJ_657 /* FigmaEffect.swift in Sources */,
-				OBJ_658 /* FigmaEffectType.swift in Sources */,
-				OBJ_659 /* FigmaExportSetting.swift in Sources */,
-				OBJ_660 /* FigmaFrameOffset.swift in Sources */,
-				OBJ_661 /* FigmaImageFormat.swift in Sources */,
-				OBJ_662 /* FigmaLayoutConstraint.swift in Sources */,
-				OBJ_663 /* FigmaLayoutGrid.swift in Sources */,
-				OBJ_664 /* FigmaLayoutGridAlignment.swift in Sources */,
-				OBJ_665 /* FigmaLayoutGridPattern.swift in Sources */,
-				OBJ_666 /* FigmaLayoutHorizontalConstraint.swift in Sources */,
-				OBJ_667 /* FigmaLayoutVerticalConstraint.swift in Sources */,
-				OBJ_668 /* FigmaLineHeightUnit.swift in Sources */,
-				OBJ_669 /* FigmaPaint.swift in Sources */,
-				OBJ_670 /* FigmaPaintType.swift in Sources */,
-				OBJ_671 /* FigmaRectangle.swift in Sources */,
-				OBJ_672 /* FigmaScaleMode.swift in Sources */,
-				OBJ_673 /* FigmaStrokeAlignment.swift in Sources */,
-				OBJ_674 /* FigmaStrokeCap.swift in Sources */,
-				OBJ_675 /* FigmaStrokeJoin.swift in Sources */,
-				OBJ_676 /* FigmaStyle.swift in Sources */,
-				OBJ_677 /* FigmaStyleType.swift in Sources */,
-				OBJ_678 /* FigmaTextCase.swift in Sources */,
-				OBJ_679 /* FigmaTextDecoration.swift in Sources */,
-				OBJ_680 /* FigmaTextHorizontalAlignment.swift in Sources */,
-				OBJ_681 /* FigmaTextVerticalAlignment.swift in Sources */,
-				OBJ_682 /* FigmaTypeStyle.swift in Sources */,
-				OBJ_683 /* FigmaVector.swift in Sources */,
-				OBJ_684 /* FigmaBooleanOperationNodePayload.swift in Sources */,
-				OBJ_685 /* FigmaCanvasNodeInfo.swift in Sources */,
-				OBJ_686 /* FigmaDocumentNodeInfo.swift in Sources */,
-				OBJ_687 /* FigmaFile.swift in Sources */,
-				OBJ_688 /* FigmaFrameNodeInfo.swift in Sources */,
-				OBJ_689 /* FigmaInstanceNodePayload.swift in Sources */,
-				OBJ_690 /* FigmaNode.swift in Sources */,
-				OBJ_691 /* FigmaNodeType.swift in Sources */,
-				OBJ_692 /* FigmaRectangleNodePayload.swift in Sources */,
-				OBJ_693 /* FigmaSliceNodeInfo.swift in Sources */,
-				OBJ_694 /* FigmaTextNodePayload.swift in Sources */,
-				OBJ_695 /* FigmaVectorNodeInfo.swift in Sources */,
-				OBJ_696 /* DefaultFigmaAPIProvider.swift in Sources */,
-				OBJ_697 /* FigmaAPIEmptyParameters.swift in Sources */,
-				OBJ_698 /* FigmaAPIEmptyResponse.swift in Sources */,
-				OBJ_699 /* FigmaAPIProvider.swift in Sources */,
-				OBJ_700 /* FigmaAPIRoute.swift in Sources */,
-				OBJ_701 /* FigmaAPIVersion.swift in Sources */,
-				OBJ_702 /* FigmaHTTPService.swift in Sources */,
-				OBJ_703 /* FigmaAPIFileRoute.swift in Sources */,
-				OBJ_704 /* FigmaAPIFileRouteQueryParameters.swift in Sources */,
-				OBJ_705 /* FigmaAPIImagesRoute.swift in Sources */,
-				OBJ_706 /* FigmaAPIImagesRouteQueryParameters.swift in Sources */,
-				OBJ_707 /* DefaultFigmaFilesProvider.swift in Sources */,
-				OBJ_708 /* FigmaFilesProvider.swift in Sources */,
-				OBJ_709 /* DefaultFigmaNodesProvider.swift in Sources */,
-				OBJ_710 /* FigmaNodesProvider.swift in Sources */,
-				OBJ_711 /* FigmaNodesProviderError.swift in Sources */,
-				OBJ_712 /* DefaultImageAssetsProvider.swift in Sources */,
-				OBJ_713 /* ImageAssetsProvider.swift in Sources */,
-				OBJ_714 /* DefaultImagesProvider.swift in Sources */,
-				OBJ_715 /* ImagesProvider.swift in Sources */,
-				OBJ_716 /* ImagesProviderError.swift in Sources */,
-				OBJ_717 /* DefaultImageRenderProvider.swift in Sources */,
-				OBJ_718 /* ImageRenderProvider.swift in Sources */,
-				OBJ_719 /* ImageRenderProviderError.swift in Sources */,
-				OBJ_720 /* DefaultImageResourcesProvider.swift in Sources */,
-				OBJ_721 /* ImageResourcesProvider.swift in Sources */,
-				C0BE783C24E9B26E004EBBEF /* StencilVectorFilter.swift in Sources */,
-				OBJ_722 /* DefaultShadowStylesProvider.swift in Sources */,
-				OBJ_723 /* ShadowStylesProvider.swift in Sources */,
-				OBJ_724 /* ShadowStylesProviderError.swift in Sources */,
-				OBJ_725 /* DefaultTextStylesProvider.swift in Sources */,
-				OBJ_726 /* TextStylesProvider.swift in Sources */,
-				OBJ_727 /* TextStylesProviderError.swift in Sources */,
-				OBJ_728 /* DefaultTemplateContextCoder.swift in Sources */,
-				OBJ_729 /* DefaultTemplateRenderer.swift in Sources */,
-				OBJ_730 /* RenderDestination.swift in Sources */,
-				OBJ_731 /* RenderTemplate.swift in Sources */,
-				OBJ_732 /* RenderTemplateType.swift in Sources */,
-				OBJ_733 /* StencilColorFilter.swift in Sources */,
-				OBJ_734 /* StencilColorInfoFilter.swift in Sources */,
-				OBJ_735 /* StencilColorRGBAHexInfoFilter.swift in Sources */,
-				OBJ_736 /* StencilColorRGBAInfoFilter.swift in Sources */,
-				OBJ_737 /* StencilColorRGBHexInfoFilter.swift in Sources */,
-				OBJ_738 /* StencilColorRGBInfoFilter.swift in Sources */,
-				OBJ_739 /* StencilFontFilter.swift in Sources */,
-				OBJ_740 /* StencilFontInfoFilter.swift in Sources */,
-				OBJ_741 /* StencilByteToFloatFilter.swift in Sources */,
-				OBJ_742 /* StencilByteToHexFilter.swift in Sources */,
-				OBJ_743 /* StencilFloatToByteFilter.swift in Sources */,
-				OBJ_744 /* StencilHexToByteFilter.swift in Sources */,
-				OBJ_745 /* StencilExtension.swift in Sources */,
-				OBJ_746 /* StencilFilter.swift in Sources */,
-				OBJ_747 /* StencilFilterError.swift in Sources */,
-				OBJ_748 /* StencilTag.swift in Sources */,
-				OBJ_749 /* StencilTagError.swift in Sources */,
-				OBJ_750 /* StencilTagNode.swift in Sources */,
-				OBJ_751 /* TemplateContextCoder.swift in Sources */,
-				OBJ_752 /* TemplateRenderer.swift in Sources */,
-				OBJ_753 /* main.swift in Sources */,
+				OBJ_585 /* AsyncExecutableCommand.swift in Sources */,
+				OBJ_586 /* ColorStylesCommand.swift in Sources */,
+				OBJ_587 /* GenerateCommand.swift in Sources */,
+				OBJ_588 /* GenerationConfigurableCommand.swift in Sources */,
+				OBJ_589 /* ImagesCommand.swift in Sources */,
+				OBJ_590 /* ShadowStylesCommand.swift in Sources */,
+				OBJ_591 /* TextStylesCommand.swift in Sources */,
+				OBJ_592 /* Dependencies.swift in Sources */,
+				OBJ_593 /* ColorStylesContext.swift in Sources */,
+				OBJ_594 /* ColorStylesGenerator.swift in Sources */,
+				OBJ_595 /* DefaultColorStylesGenerator.swift in Sources */,
+				OBJ_596 /* GenerationParametersError.swift in Sources */,
+				OBJ_597 /* GenerationParametersResolving.swift in Sources */,
+				OBJ_598 /* DefaultImagesGenerator.swift in Sources */,
+				OBJ_599 /* ImagesContext.swift in Sources */,
+				OBJ_600 /* ImagesGenerator.swift in Sources */,
+				OBJ_601 /* DefaultLibraryGenerator.swift in Sources */,
+				OBJ_602 /* LibraryGenerator.swift in Sources */,
+				OBJ_603 /* DefaultShadowStylesGenerator.swift in Sources */,
+				OBJ_604 /* ShadowStylesContext.swift in Sources */,
+				OBJ_605 /* ShadowStylesGenerator.swift in Sources */,
+				OBJ_606 /* DefaultTextStylesGenerator.swift in Sources */,
+				OBJ_607 /* TextStylesContext.swift in Sources */,
+				OBJ_608 /* TextStylesGenerator.swift in Sources */,
+				OBJ_609 /* Color.swift in Sources */,
+				OBJ_610 /* ColorStyle.swift in Sources */,
+				OBJ_611 /* ColorStyleAsset.swift in Sources */,
+				OBJ_612 /* ColorStyleNode.swift in Sources */,
+				OBJ_613 /* AccessTokenConfiguration.swift in Sources */,
+				8E53204125330481006AA460 /* StencilModificatorError.swift in Sources */,
+				OBJ_614 /* BaseConfiguration.swift in Sources */,
+				OBJ_615 /* ColorStylesConfiguration.swift in Sources */,
+				OBJ_616 /* Configuration.swift in Sources */,
+				OBJ_617 /* FileConfiguration.swift in Sources */,
+				OBJ_618 /* GenerationConfiguration.swift in Sources */,
+				OBJ_619 /* ImagesConfiguration.swift in Sources */,
+				8E53205D25330490006AA460 /* StencilFontInitializerModificator.swift in Sources */,
+				OBJ_620 /* ShadowStylesConfiguration.swift in Sources */,
+				OBJ_621 /* TextStylesConfiguration.swift in Sources */,
+				OBJ_622 /* Font.swift in Sources */,
+				OBJ_623 /* Image.swift in Sources */,
+				OBJ_624 /* ImageAsset.swift in Sources */,
+				OBJ_625 /* ImageFormat.swift in Sources */,
+				OBJ_626 /* ImageNode.swift in Sources */,
+				OBJ_627 /* ImageRenderedNode.swift in Sources */,
+				OBJ_628 /* ImageResource.swift in Sources */,
+				OBJ_629 /* ImageScale.swift in Sources */,
+				OBJ_630 /* FileParameters.swift in Sources */,
+				OBJ_631 /* GenerationParameters.swift in Sources */,
+				OBJ_632 /* ImagesParameters.swift in Sources */,
+				8E53205C25330490006AA460 /* StencilFontModificator.swift in Sources */,
+				OBJ_633 /* NodesParameters.swift in Sources */,
+				OBJ_634 /* RenderParameters.swift in Sources */,
+				OBJ_635 /* Shadow.swift in Sources */,
+				OBJ_636 /* ShadowStyle.swift in Sources */,
+				OBJ_637 /* ShadowStyleNode.swift in Sources */,
+				OBJ_638 /* ShadowType.swift in Sources */,
+				OBJ_639 /* TextStyle.swift in Sources */,
+				OBJ_640 /* TextStyleColor.swift in Sources */,
+				OBJ_641 /* TextStyleNode.swift in Sources */,
+				OBJ_642 /* Vector.swift in Sources */,
+				OBJ_643 /* AssetsProvider.swift in Sources */,
+				OBJ_644 /* DefaultAssetsProvider.swift in Sources */,
+				OBJ_645 /* ColorStyleAssetsProvider.swift in Sources */,
+				OBJ_646 /* DefaultColorStyleAssetsProvider.swift in Sources */,
+				OBJ_647 /* ColorStylesProvider.swift in Sources */,
+				OBJ_648 /* ColorStylesProviderError.swift in Sources */,
+				OBJ_649 /* DefaultColorStylesProvider.swift in Sources */,
+				OBJ_650 /* ConfigurationProvider.swift in Sources */,
+				OBJ_651 /* DefaultConfigurationProvider.swift in Sources */,
+				8E53204025330481006AA460 /* StencilModificator.swift in Sources */,
+				OBJ_652 /* DataProvider.swift in Sources */,
+				OBJ_653 /* DefaultDataProvider.swift in Sources */,
+				OBJ_654 /* FigmaError.swift in Sources */,
+				OBJ_655 /* FigmaImages.swift in Sources */,
+				OBJ_656 /* FigmaBlendMode.swift in Sources */,
+				OBJ_657 /* FigmaBooleanOperationType.swift in Sources */,
+				OBJ_658 /* FigmaColor.swift in Sources */,
+				OBJ_659 /* FigmaColorStop.swift in Sources */,
+				OBJ_660 /* FigmaComponent.swift in Sources */,
+				OBJ_661 /* FigmaConstraint.swift in Sources */,
+				OBJ_662 /* FigmaConstraintType.swift in Sources */,
+				OBJ_663 /* FigmaEasingType.swift in Sources */,
+				OBJ_664 /* FigmaEffect.swift in Sources */,
+				OBJ_665 /* FigmaEffectType.swift in Sources */,
+				OBJ_666 /* FigmaExportSetting.swift in Sources */,
+				OBJ_667 /* FigmaFrameOffset.swift in Sources */,
+				OBJ_668 /* FigmaImageFormat.swift in Sources */,
+				OBJ_669 /* FigmaLayoutConstraint.swift in Sources */,
+				OBJ_670 /* FigmaLayoutGrid.swift in Sources */,
+				OBJ_671 /* FigmaLayoutGridAlignment.swift in Sources */,
+				OBJ_672 /* FigmaLayoutGridPattern.swift in Sources */,
+				OBJ_673 /* FigmaLayoutHorizontalConstraint.swift in Sources */,
+				OBJ_674 /* FigmaLayoutVerticalConstraint.swift in Sources */,
+				OBJ_675 /* FigmaLineHeightUnit.swift in Sources */,
+				OBJ_676 /* FigmaPaint.swift in Sources */,
+				OBJ_677 /* FigmaPaintType.swift in Sources */,
+				OBJ_678 /* FigmaRectangle.swift in Sources */,
+				OBJ_679 /* FigmaScaleMode.swift in Sources */,
+				OBJ_680 /* FigmaStrokeAlignment.swift in Sources */,
+				OBJ_681 /* FigmaStrokeCap.swift in Sources */,
+				OBJ_682 /* FigmaStrokeJoin.swift in Sources */,
+				OBJ_683 /* FigmaStyle.swift in Sources */,
+				OBJ_684 /* FigmaStyleType.swift in Sources */,
+				OBJ_685 /* FigmaTextCase.swift in Sources */,
+				OBJ_686 /* FigmaTextDecoration.swift in Sources */,
+				OBJ_687 /* FigmaTextHorizontalAlignment.swift in Sources */,
+				OBJ_688 /* FigmaTextVerticalAlignment.swift in Sources */,
+				OBJ_689 /* FigmaTypeStyle.swift in Sources */,
+				OBJ_690 /* FigmaVector.swift in Sources */,
+				OBJ_691 /* FigmaBooleanOperationNodePayload.swift in Sources */,
+				OBJ_692 /* FigmaCanvasNodeInfo.swift in Sources */,
+				OBJ_693 /* FigmaDocumentNodeInfo.swift in Sources */,
+				OBJ_694 /* FigmaFile.swift in Sources */,
+				8E5320A725335F8A006AA460 /* StencilFontSystemFilter.swift in Sources */,
+				OBJ_695 /* FigmaFrameNodeInfo.swift in Sources */,
+				OBJ_696 /* FigmaInstanceNodePayload.swift in Sources */,
+				OBJ_697 /* FigmaNode.swift in Sources */,
+				OBJ_698 /* FigmaNodeType.swift in Sources */,
+				OBJ_699 /* FigmaRectangleNodePayload.swift in Sources */,
+				OBJ_700 /* FigmaSliceNodeInfo.swift in Sources */,
+				OBJ_701 /* FigmaTextNodePayload.swift in Sources */,
+				OBJ_702 /* FigmaVectorNodeInfo.swift in Sources */,
+				OBJ_703 /* DefaultFigmaAPIProvider.swift in Sources */,
+				OBJ_704 /* FigmaAPIEmptyParameters.swift in Sources */,
+				OBJ_705 /* FigmaAPIEmptyResponse.swift in Sources */,
+				OBJ_706 /* FigmaAPIProvider.swift in Sources */,
+				OBJ_707 /* FigmaAPIRoute.swift in Sources */,
+				OBJ_708 /* FigmaAPIVersion.swift in Sources */,
+				OBJ_709 /* FigmaHTTPService.swift in Sources */,
+				OBJ_710 /* FigmaAPIFileRoute.swift in Sources */,
+				OBJ_711 /* FigmaAPIFileRouteQueryParameters.swift in Sources */,
+				OBJ_712 /* FigmaAPIImagesRoute.swift in Sources */,
+				OBJ_713 /* FigmaAPIImagesRouteQueryParameters.swift in Sources */,
+				OBJ_714 /* DefaultFigmaFilesProvider.swift in Sources */,
+				OBJ_715 /* FigmaFilesProvider.swift in Sources */,
+				OBJ_716 /* DefaultFigmaNodesProvider.swift in Sources */,
+				OBJ_717 /* FigmaNodesProvider.swift in Sources */,
+				OBJ_718 /* FigmaNodesProviderError.swift in Sources */,
+				OBJ_719 /* DefaultImageAssetsProvider.swift in Sources */,
+				OBJ_720 /* ImageAssetsProvider.swift in Sources */,
+				OBJ_721 /* DefaultImagesProvider.swift in Sources */,
+				OBJ_722 /* ImagesProvider.swift in Sources */,
+				OBJ_723 /* ImagesProviderError.swift in Sources */,
+				OBJ_724 /* DefaultImageRenderProvider.swift in Sources */,
+				OBJ_725 /* ImageRenderProvider.swift in Sources */,
+				OBJ_726 /* ImageRenderProviderError.swift in Sources */,
+				OBJ_727 /* DefaultImageResourcesProvider.swift in Sources */,
+				OBJ_728 /* ImageResourcesProvider.swift in Sources */,
+				OBJ_729 /* DefaultShadowStylesProvider.swift in Sources */,
+				OBJ_730 /* ShadowStylesProvider.swift in Sources */,
+				OBJ_731 /* ShadowStylesProviderError.swift in Sources */,
+				OBJ_732 /* DefaultTextStylesProvider.swift in Sources */,
+				OBJ_733 /* TextStylesProvider.swift in Sources */,
+				OBJ_734 /* TextStylesProviderError.swift in Sources */,
+				OBJ_735 /* DefaultTemplateContextCoder.swift in Sources */,
+				OBJ_736 /* DefaultTemplateRenderer.swift in Sources */,
+				OBJ_737 /* RenderDestination.swift in Sources */,
+				OBJ_738 /* RenderTemplate.swift in Sources */,
+				OBJ_739 /* RenderTemplateType.swift in Sources */,
+				OBJ_740 /* StencilColorFilter.swift in Sources */,
+				OBJ_741 /* StencilColorInfoFilter.swift in Sources */,
+				OBJ_742 /* StencilColorRGBAHexInfoFilter.swift in Sources */,
+				OBJ_743 /* StencilColorRGBAInfoFilter.swift in Sources */,
+				OBJ_744 /* StencilColorRGBHexInfoFilter.swift in Sources */,
+				OBJ_745 /* StencilColorRGBInfoFilter.swift in Sources */,
+				OBJ_746 /* StencilFontFilter.swift in Sources */,
+				OBJ_747 /* StencilFontInfoFilter.swift in Sources */,
+				OBJ_748 /* StencilByteToFloatFilter.swift in Sources */,
+				OBJ_749 /* StencilByteToHexFilter.swift in Sources */,
+				OBJ_750 /* StencilFloatToByteFilter.swift in Sources */,
+				OBJ_751 /* StencilHexToByteFilter.swift in Sources */,
+				OBJ_752 /* StencilExtension.swift in Sources */,
+				OBJ_753 /* StencilFilter.swift in Sources */,
+				OBJ_754 /* StencilFilterError.swift in Sources */,
+				OBJ_755 /* StencilTag.swift in Sources */,
+				OBJ_756 /* StencilTagError.swift in Sources */,
+				OBJ_757 /* StencilTagNode.swift in Sources */,
+				OBJ_758 /* StencilVectorFilter.swift in Sources */,
+				OBJ_759 /* StencilVectorInfoFilter.swift in Sources */,
+				OBJ_760 /* TemplateContextCoder.swift in Sources */,
+				OBJ_761 /* TemplateRenderer.swift in Sources */,
+				OBJ_762 /* main.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_787 /* Sources */ = {
+		OBJ_796 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_788 /* Package.swift in Sources */,
+				OBJ_797 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_800 /* Sources */ = {
+		OBJ_809 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_801 /* FugenTests.swift in Sources */,
-				OBJ_802 /* XCTestManifests.swift in Sources */,
+				OBJ_810 /* FugenTests.swift in Sources */,
+				OBJ_811 /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_828 /* Sources */ = {
+		OBJ_837 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_829 /* AssetAppearance.swift in Sources */,
-				OBJ_830 /* AssetAppearanceContrast.swift in Sources */,
-				OBJ_831 /* AssetAppearanceLuminosity.swift in Sources */,
-				OBJ_832 /* AssetCompressionType.swift in Sources */,
-				OBJ_833 /* AssetDisplayGamut.swift in Sources */,
-				OBJ_834 /* AssetIdiom.swift in Sources */,
-				OBJ_835 /* AssetIdiomIPadSubtype.swift in Sources */,
-				OBJ_836 /* AssetInfo.swift in Sources */,
-				OBJ_837 /* AssetNode.swift in Sources */,
-				OBJ_838 /* AssetColor.swift in Sources */,
-				OBJ_839 /* AssetColorComponents.swift in Sources */,
-				OBJ_840 /* AssetColorContent.swift in Sources */,
-				OBJ_841 /* AssetColorGrayscale.swift in Sources */,
-				OBJ_842 /* AssetColorSet.swift in Sources */,
-				OBJ_843 /* AssetColorSetContents.swift in Sources */,
-				OBJ_844 /* AssetCustomColor.swift in Sources */,
-				OBJ_845 /* AssetSystemColor.swift in Sources */,
-				OBJ_846 /* AssetSystemColorPlatform.swift in Sources */,
-				OBJ_847 /* AssetFolder.swift in Sources */,
-				OBJ_848 /* AssetFolderContents.swift in Sources */,
-				OBJ_849 /* AssetFolderProperties.swift in Sources */,
-				OBJ_850 /* AssetImage.swift in Sources */,
-				OBJ_851 /* AssetImageAlignmentInsets.swift in Sources */,
-				OBJ_852 /* AssetImageAutoScaling.swift in Sources */,
-				OBJ_853 /* AssetImageGraphicsFeatureSet.swift in Sources */,
-				OBJ_854 /* AssetImageLanguageDirection.swift in Sources */,
-				OBJ_855 /* AssetImageMemory.swift in Sources */,
-				OBJ_856 /* AssetImageProperties.swift in Sources */,
-				OBJ_857 /* AssetImageScale.swift in Sources */,
-				OBJ_858 /* AssetImageSet.swift in Sources */,
-				OBJ_859 /* AssetImageSetContents.swift in Sources */,
-				OBJ_860 /* AssetImageSizeClass.swift in Sources */,
-				OBJ_861 /* AssetImageTemplateRenderingIntent.swift in Sources */,
-				OBJ_862 /* Bundle+Extensions.swift in Sources */,
-				OBJ_863 /* CLI+Extensions.swift in Sources */,
-				OBJ_864 /* Collection+Extensions.swift in Sources */,
-				OBJ_865 /* Decodable+Extensions.swift in Sources */,
-				OBJ_866 /* DispatchQueue+Extensions.swift in Sources */,
-				OBJ_867 /* Encodable+Extensions.swift in Sources */,
-				OBJ_868 /* FloatingPoint+Extensions.swift in Sources */,
-				OBJ_869 /* JSONDecoder+Extensions.swift in Sources */,
-				OBJ_870 /* JSONEncoder+Extensions.swift in Sources */,
-				OBJ_871 /* KeyedDecodingContainerProtocol+Extensions.swift in Sources */,
-				OBJ_872 /* OperatingSystemVersion+Extensions.swift in Sources */,
-				OBJ_873 /* Optional+Extensions.swift in Sources */,
-				OBJ_874 /* Path+Extensions.swift in Sources */,
-				OBJ_875 /* ProcessInfo+Extensions.swift in Sources */,
-				OBJ_876 /* Promise+Extensions.swift in Sources */,
-				OBJ_877 /* RangeReplaceableCollection+Extensions.swift in Sources */,
-				OBJ_878 /* Sequence+Extensions.swift in Sources */,
-				OBJ_879 /* SingleValueDecodingContainer+Extensions.swift in Sources */,
-				OBJ_880 /* String+Extensions.swift in Sources */,
-				OBJ_881 /* UnkeyedDecodingContainer+Extensions.swift in Sources */,
-				OBJ_882 /* HTTPBodyEncoder.swift in Sources */,
-				OBJ_883 /* HTTPBodyJSONEncoder.swift in Sources */,
-				OBJ_884 /* HTTPBodyURLEncoder.swift in Sources */,
-				OBJ_885 /* HTTPActivityIndicator.swift in Sources */,
-				OBJ_886 /* HTTPAnyEncodable.swift in Sources */,
-				OBJ_887 /* HTTPError.swift in Sources */,
-				OBJ_888 /* HTTPErrorStringConvertible.swift in Sources */,
-				OBJ_889 /* HTTPHeader.swift in Sources */,
-				OBJ_890 /* HTTPMethod.swift in Sources */,
-				OBJ_891 /* HTTPResponse.swift in Sources */,
-				OBJ_892 /* HTTPRoute.swift in Sources */,
-				OBJ_893 /* HTTPService.swift in Sources */,
-				OBJ_894 /* HTTPServiceTask.swift in Sources */,
-				OBJ_895 /* HTTPStatusCode.swift in Sources */,
-				OBJ_896 /* HTTPTask.swift in Sources */,
-				OBJ_897 /* HTTPUIActivityIndicator.swift in Sources */,
-				OBJ_898 /* HTTPQueryEncoder.swift in Sources */,
-				OBJ_899 /* HTTPQueryURLEncoder.swift in Sources */,
-				OBJ_900 /* HTTPDataResponseSerializer.swift in Sources */,
-				OBJ_901 /* HTTPDecodableResponseSerializer.swift in Sources */,
-				OBJ_902 /* HTTPEmptyResponse.swift in Sources */,
-				OBJ_903 /* HTTPJSONResponseSerializer.swift in Sources */,
-				OBJ_904 /* HTTPResponseDecoder.swift in Sources */,
-				OBJ_905 /* HTTPResponseSerializer.swift in Sources */,
-				OBJ_906 /* HTTPStringResponseSerializer.swift in Sources */,
-				OBJ_907 /* AnyCodable.swift in Sources */,
-				OBJ_908 /* AnyCodingKey.swift in Sources */,
-				OBJ_909 /* Cache.swift in Sources */,
-				OBJ_910 /* MessageError.swift in Sources */,
-				OBJ_911 /* URLArrayEncodingStrategy.swift in Sources */,
-				OBJ_912 /* URLBoolEncodingStrategy.swift in Sources */,
-				OBJ_913 /* URLDateEncodingStrategy.swift in Sources */,
-				OBJ_914 /* URLEncodedForm.swift in Sources */,
-				OBJ_915 /* URLEncodedFormComponent.swift in Sources */,
-				OBJ_916 /* URLEncodedFormContext.swift in Sources */,
-				OBJ_917 /* URLEncodedFormEncoder.swift in Sources */,
-				OBJ_918 /* URLEncodedFormKeyedEncodingContainer.swift in Sources */,
-				OBJ_919 /* URLEncodedFormSerializer.swift in Sources */,
-				OBJ_920 /* URLEncodedFormSingleValueEncodingContainer.swift in Sources */,
-				OBJ_921 /* URLEncodedFormUnkeyedEncodingContainer.swift in Sources */,
-				OBJ_922 /* URLEncoder.swift in Sources */,
-				OBJ_923 /* URLSpaceEncodingStrategy.swift in Sources */,
+				OBJ_838 /* AssetAppearance.swift in Sources */,
+				OBJ_839 /* AssetAppearanceContrast.swift in Sources */,
+				OBJ_840 /* AssetAppearanceLuminosity.swift in Sources */,
+				OBJ_841 /* AssetCompressionType.swift in Sources */,
+				OBJ_842 /* AssetDisplayGamut.swift in Sources */,
+				OBJ_843 /* AssetIdiom.swift in Sources */,
+				OBJ_844 /* AssetIdiomIPadSubtype.swift in Sources */,
+				OBJ_845 /* AssetInfo.swift in Sources */,
+				OBJ_846 /* AssetNode.swift in Sources */,
+				OBJ_847 /* AssetColor.swift in Sources */,
+				OBJ_848 /* AssetColorComponents.swift in Sources */,
+				OBJ_849 /* AssetColorContent.swift in Sources */,
+				OBJ_850 /* AssetColorGrayscale.swift in Sources */,
+				OBJ_851 /* AssetColorSet.swift in Sources */,
+				OBJ_852 /* AssetColorSetContents.swift in Sources */,
+				OBJ_853 /* AssetCustomColor.swift in Sources */,
+				OBJ_854 /* AssetSystemColor.swift in Sources */,
+				OBJ_855 /* AssetSystemColorPlatform.swift in Sources */,
+				OBJ_856 /* AssetFolder.swift in Sources */,
+				OBJ_857 /* AssetFolderContents.swift in Sources */,
+				OBJ_858 /* AssetFolderProperties.swift in Sources */,
+				OBJ_859 /* AssetImage.swift in Sources */,
+				OBJ_860 /* AssetImageAlignmentInsets.swift in Sources */,
+				OBJ_861 /* AssetImageAutoScaling.swift in Sources */,
+				OBJ_862 /* AssetImageGraphicsFeatureSet.swift in Sources */,
+				OBJ_863 /* AssetImageLanguageDirection.swift in Sources */,
+				OBJ_864 /* AssetImageMemory.swift in Sources */,
+				OBJ_865 /* AssetImageProperties.swift in Sources */,
+				OBJ_866 /* AssetImageScale.swift in Sources */,
+				OBJ_867 /* AssetImageSet.swift in Sources */,
+				OBJ_868 /* AssetImageSetContents.swift in Sources */,
+				OBJ_869 /* AssetImageSizeClass.swift in Sources */,
+				OBJ_870 /* AssetImageTemplateRenderingIntent.swift in Sources */,
+				OBJ_871 /* Bundle+Extensions.swift in Sources */,
+				OBJ_872 /* CLI+Extensions.swift in Sources */,
+				OBJ_873 /* Collection+Extensions.swift in Sources */,
+				OBJ_874 /* Decodable+Extensions.swift in Sources */,
+				OBJ_875 /* DispatchQueue+Extensions.swift in Sources */,
+				OBJ_876 /* Encodable+Extensions.swift in Sources */,
+				OBJ_877 /* FloatingPoint+Extensions.swift in Sources */,
+				OBJ_878 /* JSONDecoder+Extensions.swift in Sources */,
+				OBJ_879 /* JSONEncoder+Extensions.swift in Sources */,
+				OBJ_880 /* KeyedDecodingContainerProtocol+Extensions.swift in Sources */,
+				OBJ_881 /* OperatingSystemVersion+Extensions.swift in Sources */,
+				OBJ_882 /* Optional+Extensions.swift in Sources */,
+				OBJ_883 /* Path+Extensions.swift in Sources */,
+				OBJ_884 /* ProcessInfo+Extensions.swift in Sources */,
+				OBJ_885 /* Promise+Extensions.swift in Sources */,
+				OBJ_886 /* RangeReplaceableCollection+Extensions.swift in Sources */,
+				OBJ_887 /* Sequence+Extensions.swift in Sources */,
+				OBJ_888 /* SingleValueDecodingContainer+Extensions.swift in Sources */,
+				OBJ_889 /* String+Extensions.swift in Sources */,
+				OBJ_890 /* UnkeyedDecodingContainer+Extensions.swift in Sources */,
+				OBJ_891 /* HTTPBodyEncoder.swift in Sources */,
+				OBJ_892 /* HTTPBodyJSONEncoder.swift in Sources */,
+				OBJ_893 /* HTTPBodyURLEncoder.swift in Sources */,
+				OBJ_894 /* HTTPActivityIndicator.swift in Sources */,
+				OBJ_895 /* HTTPAnyEncodable.swift in Sources */,
+				OBJ_896 /* HTTPError.swift in Sources */,
+				OBJ_897 /* HTTPErrorStringConvertible.swift in Sources */,
+				OBJ_898 /* HTTPHeader.swift in Sources */,
+				OBJ_899 /* HTTPMethod.swift in Sources */,
+				OBJ_900 /* HTTPResponse.swift in Sources */,
+				OBJ_901 /* HTTPRoute.swift in Sources */,
+				OBJ_902 /* HTTPService.swift in Sources */,
+				OBJ_903 /* HTTPServiceTask.swift in Sources */,
+				OBJ_904 /* HTTPStatusCode.swift in Sources */,
+				OBJ_905 /* HTTPTask.swift in Sources */,
+				OBJ_906 /* HTTPUIActivityIndicator.swift in Sources */,
+				OBJ_907 /* HTTPQueryEncoder.swift in Sources */,
+				OBJ_908 /* HTTPQueryURLEncoder.swift in Sources */,
+				OBJ_909 /* HTTPDataResponseSerializer.swift in Sources */,
+				OBJ_910 /* HTTPDecodableResponseSerializer.swift in Sources */,
+				OBJ_911 /* HTTPEmptyResponse.swift in Sources */,
+				OBJ_912 /* HTTPJSONResponseSerializer.swift in Sources */,
+				OBJ_913 /* HTTPResponseDecoder.swift in Sources */,
+				OBJ_914 /* HTTPResponseSerializer.swift in Sources */,
+				OBJ_915 /* HTTPStringResponseSerializer.swift in Sources */,
+				OBJ_916 /* AnyCodable.swift in Sources */,
+				OBJ_917 /* AnyCodingKey.swift in Sources */,
+				OBJ_918 /* Cache.swift in Sources */,
+				OBJ_919 /* MessageError.swift in Sources */,
+				OBJ_920 /* URLArrayEncodingStrategy.swift in Sources */,
+				OBJ_921 /* URLBoolEncodingStrategy.swift in Sources */,
+				OBJ_922 /* URLDateEncodingStrategy.swift in Sources */,
+				OBJ_923 /* URLEncodedForm.swift in Sources */,
+				OBJ_924 /* URLEncodedFormComponent.swift in Sources */,
+				OBJ_925 /* URLEncodedFormContext.swift in Sources */,
+				OBJ_926 /* URLEncodedFormEncoder.swift in Sources */,
+				OBJ_927 /* URLEncodedFormKeyedEncodingContainer.swift in Sources */,
+				OBJ_928 /* URLEncodedFormSerializer.swift in Sources */,
+				OBJ_929 /* URLEncodedFormSingleValueEncodingContainer.swift in Sources */,
+				OBJ_930 /* URLEncodedFormUnkeyedEncodingContainer.swift in Sources */,
+				OBJ_931 /* URLEncoder.swift in Sources */,
+				OBJ_932 /* URLSpaceEncodingStrategy.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_934 /* Sources */ = {
+		OBJ_943 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_935 /* FugenToolsTests.swift in Sources */,
-				OBJ_936 /* XCTestManifests.swift in Sources */,
+				OBJ_944 /* FugenToolsTests.swift in Sources */,
+				OBJ_945 /* XCTestManifests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_949 /* Sources */ = {
+		OBJ_958 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_950 /* PathKit.swift in Sources */,
+				OBJ_959 /* PathKit.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_956 /* Sources */ = {
+		OBJ_965 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_957 /* Package.swift in Sources */,
+				OBJ_966 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_961 /* Sources */ = {
+		OBJ_970 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_962 /* Box.swift in Sources */,
-				OBJ_963 /* Catchable.swift in Sources */,
-				OBJ_964 /* Configuration.swift in Sources */,
-				OBJ_965 /* CustomStringConvertible.swift in Sources */,
-				OBJ_966 /* Error.swift in Sources */,
-				OBJ_967 /* Guarantee.swift in Sources */,
-				OBJ_968 /* LogEvent.swift in Sources */,
-				OBJ_969 /* Promise.swift in Sources */,
-				OBJ_970 /* Resolver.swift in Sources */,
-				OBJ_971 /* Thenable.swift in Sources */,
-				OBJ_972 /* after.swift in Sources */,
-				OBJ_973 /* firstly.swift in Sources */,
-				OBJ_974 /* hang.swift in Sources */,
-				OBJ_975 /* race.swift in Sources */,
-				OBJ_976 /* when.swift in Sources */,
+				OBJ_971 /* Box.swift in Sources */,
+				OBJ_972 /* Catchable.swift in Sources */,
+				OBJ_973 /* Configuration.swift in Sources */,
+				OBJ_974 /* CustomStringConvertible.swift in Sources */,
+				OBJ_975 /* Error.swift in Sources */,
+				OBJ_976 /* Guarantee.swift in Sources */,
+				OBJ_977 /* LogEvent.swift in Sources */,
+				OBJ_978 /* Promise.swift in Sources */,
+				OBJ_979 /* Resolver.swift in Sources */,
+				OBJ_980 /* Thenable.swift in Sources */,
+				OBJ_981 /* after.swift in Sources */,
+				OBJ_982 /* firstly.swift in Sources */,
+				OBJ_983 /* hang.swift in Sources */,
+				OBJ_984 /* race.swift in Sources */,
+				OBJ_985 /* when.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_982 /* Sources */ = {
+		OBJ_991 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_983 /* Package.swift in Sources */,
+				OBJ_992 /* Package.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		OBJ_987 /* Sources */ = {
+		OBJ_996 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				OBJ_988 /* BackgroundColor.swift in Sources */,
-				OBJ_989 /* CodesParser.swift in Sources */,
-				OBJ_990 /* Color.swift in Sources */,
-				OBJ_991 /* ControlCode.swift in Sources */,
-				OBJ_992 /* ModesExtractor.swift in Sources */,
-				OBJ_993 /* OutputTarget.swift in Sources */,
-				OBJ_994 /* Rainbow.swift in Sources */,
-				OBJ_995 /* String+Rainbow.swift in Sources */,
-				OBJ_996 /* StringGenerator.swift in Sources */,
-				OBJ_997 /* Style.swift in Sources */,
-				OBJ_998 /* XcodeColorsSupport.swift in Sources */,
+				OBJ_997 /* BackgroundColor.swift in Sources */,
+				OBJ_998 /* CodesParser.swift in Sources */,
+				OBJ_999 /* Color.swift in Sources */,
+				OBJ_1000 /* ControlCode.swift in Sources */,
+				OBJ_1001 /* ModesExtractor.swift in Sources */,
+				OBJ_1002 /* OutputTarget.swift in Sources */,
+				OBJ_1003 /* Rainbow.swift in Sources */,
+				OBJ_1004 /* String+Rainbow.swift in Sources */,
+				OBJ_1005 /* StringGenerator.swift in Sources */,
+				OBJ_1006 /* Style.swift in Sources */,
+				OBJ_1007 /* XcodeColorsSupport.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		OBJ_1032 /* PBXTargetDependency */ = {
+		OBJ_1041 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "PathKit::PathKit" /* PathKit */;
-			targetProxy = C042746824E8499E00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E532006253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_1057 /* PBXTargetDependency */ = {
+		OBJ_1066 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Stencil::Stencil" /* Stencil */;
-			targetProxy = C042746724E8499E00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E532005253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_1058 /* PBXTargetDependency */ = {
+		OBJ_1067 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "PathKit::PathKit" /* PathKit */;
-			targetProxy = C042746924E8499E00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E532007253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_1120 /* PBXTargetDependency */ = {
+		OBJ_1129 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Yams::CYaml" /* CYaml */;
-			targetProxy = C042746D24E8499E00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E53200B253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_1131 /* PBXTargetDependency */ = {
+		OBJ_1140 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Fugen::Fugen" /* Fugen */;
-			targetProxy = C042748724E849A000E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_765 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "DictionaryCoder::DictionaryCoder" /* DictionaryCoder */;
-			targetProxy = C042746524E8499E00E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_766 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "StencilSwiftKit::StencilSwiftKit" /* StencilSwiftKit */;
-			targetProxy = C042746624E8499E00E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_768 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Stencil::Stencil" /* Stencil */;
-			targetProxy = C042746A24E8499E00E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_770 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Rainbow::Rainbow" /* Rainbow */;
-			targetProxy = C042746B24E8499E00E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_772 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Yams::Yams" /* Yams */;
-			targetProxy = C042746C24E8499E00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E53203C253303CB006AA460 /* PBXContainerItemProxy */;
 		};
 		OBJ_774 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "Yams::CYaml" /* CYaml */;
-			targetProxy = C042746E24E8499E00E1605C /* PBXContainerItemProxy */;
+			target = "DictionaryCoder::DictionaryCoder" /* DictionaryCoder */;
+			targetProxy = 8E532003253303C9006AA460 /* PBXContainerItemProxy */;
 		};
 		OBJ_775 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "Fugen::FugenTools" /* FugenTools */;
-			targetProxy = C042746F24E8499E00E1605C /* PBXContainerItemProxy */;
+			target = "StencilSwiftKit::StencilSwiftKit" /* StencilSwiftKit */;
+			targetProxy = 8E532004253303C9006AA460 /* PBXContainerItemProxy */;
 		};
 		OBJ_777 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "PromiseKit::PromiseKit" /* PromiseKit */;
-			targetProxy = C042747324E8499E00E1605C /* PBXContainerItemProxy */;
+			target = "Stencil::Stencil" /* Stencil */;
+			targetProxy = 8E532008253303C9006AA460 /* PBXContainerItemProxy */;
 		};
 		OBJ_779 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "PathKit::PathKit" /* PathKit */;
-			targetProxy = C042747424E8499E00E1605C /* PBXContainerItemProxy */;
+			target = "Rainbow::Rainbow" /* Rainbow */;
+			targetProxy = 8E532009253303C9006AA460 /* PBXContainerItemProxy */;
 		};
 		OBJ_781 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "SwiftCLI::SwiftCLI" /* SwiftCLI */;
-			targetProxy = C042747524E8499E00E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_793 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Fugen::FugenTests" /* FugenTests */;
-			targetProxy = C042748524E849A000E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_795 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Fugen::FugenToolsTests" /* FugenToolsTests */;
-			targetProxy = C042748624E849A000E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_814 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Fugen::Fugen" /* Fugen */;
-			targetProxy = C042747A24E8499F00E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_815 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "DictionaryCoder::DictionaryCoder" /* DictionaryCoder */;
-			targetProxy = C042747B24E8499F00E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_816 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "StencilSwiftKit::StencilSwiftKit" /* StencilSwiftKit */;
-			targetProxy = C042747C24E8499F00E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_817 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Stencil::Stencil" /* Stencil */;
-			targetProxy = C042747D24E8499F00E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_818 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = "Rainbow::Rainbow" /* Rainbow */;
-			targetProxy = C042747E24E8499F00E1605C /* PBXContainerItemProxy */;
-		};
-		OBJ_819 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
 			target = "Yams::Yams" /* Yams */;
-			targetProxy = C042747F24E8499F00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E53200A253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_820 /* PBXTargetDependency */ = {
+		OBJ_783 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Yams::CYaml" /* CYaml */;
-			targetProxy = C042748024E8499F00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E53200C253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_821 /* PBXTargetDependency */ = {
+		OBJ_784 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Fugen::FugenTools" /* FugenTools */;
-			targetProxy = C042748124E8499F00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E53200D253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_822 /* PBXTargetDependency */ = {
+		OBJ_786 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "PromiseKit::PromiseKit" /* PromiseKit */;
-			targetProxy = C042748224E8499F00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E532011253303C9006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_788 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "PathKit::PathKit" /* PathKit */;
+			targetProxy = 8E532012253303C9006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_790 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftCLI::SwiftCLI" /* SwiftCLI */;
+			targetProxy = 8E532013253303C9006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_802 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Fugen::FugenTests" /* FugenTests */;
+			targetProxy = 8E532028253303CB006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_804 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Fugen::FugenToolsTests" /* FugenToolsTests */;
+			targetProxy = 8E532029253303CB006AA460 /* PBXContainerItemProxy */;
 		};
 		OBJ_823 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "PathKit::PathKit" /* PathKit */;
-			targetProxy = C042748324E8499F00E1605C /* PBXContainerItemProxy */;
+			target = "Fugen::Fugen" /* Fugen */;
+			targetProxy = 8E532018253303C9006AA460 /* PBXContainerItemProxy */;
 		};
 		OBJ_824 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "SwiftCLI::SwiftCLI" /* SwiftCLI */;
-			targetProxy = C042748424E8499F00E1605C /* PBXContainerItemProxy */;
+			target = "DictionaryCoder::DictionaryCoder" /* DictionaryCoder */;
+			targetProxy = 8E532019253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_928 /* PBXTargetDependency */ = {
+		OBJ_825 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "PromiseKit::PromiseKit" /* PromiseKit */;
-			targetProxy = C042747024E8499E00E1605C /* PBXContainerItemProxy */;
+			target = "StencilSwiftKit::StencilSwiftKit" /* StencilSwiftKit */;
+			targetProxy = 8E53201A253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_929 /* PBXTargetDependency */ = {
+		OBJ_826 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "PathKit::PathKit" /* PathKit */;
-			targetProxy = C042747124E8499E00E1605C /* PBXContainerItemProxy */;
+			target = "Stencil::Stencil" /* Stencil */;
+			targetProxy = 8E53201B253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_930 /* PBXTargetDependency */ = {
+		OBJ_827 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "SwiftCLI::SwiftCLI" /* SwiftCLI */;
-			targetProxy = C042747224E8499E00E1605C /* PBXContainerItemProxy */;
+			target = "Rainbow::Rainbow" /* Rainbow */;
+			targetProxy = 8E53201C253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_942 /* PBXTargetDependency */ = {
+		OBJ_828 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Yams::Yams" /* Yams */;
+			targetProxy = 8E53201D253303C9006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_829 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Yams::CYaml" /* CYaml */;
+			targetProxy = 8E53201E253303C9006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_830 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "Fugen::FugenTools" /* FugenTools */;
-			targetProxy = C042747624E8499F00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E53201F253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_943 /* PBXTargetDependency */ = {
+		OBJ_831 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "PromiseKit::PromiseKit" /* PromiseKit */;
-			targetProxy = C042747724E8499F00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E532020253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_944 /* PBXTargetDependency */ = {
+		OBJ_832 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "PathKit::PathKit" /* PathKit */;
-			targetProxy = C042747824E8499F00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E532021253303C9006AA460 /* PBXContainerItemProxy */;
 		};
-		OBJ_945 /* PBXTargetDependency */ = {
+		OBJ_833 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "SwiftCLI::SwiftCLI" /* SwiftCLI */;
-			targetProxy = C042747924E8499F00E1605C /* PBXContainerItemProxy */;
+			targetProxy = 8E532022253303C9006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_937 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "PromiseKit::PromiseKit" /* PromiseKit */;
+			targetProxy = 8E53200E253303C9006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_938 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "PathKit::PathKit" /* PathKit */;
+			targetProxy = 8E53200F253303C9006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_939 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftCLI::SwiftCLI" /* SwiftCLI */;
+			targetProxy = 8E532010253303C9006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_951 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "Fugen::FugenTools" /* FugenTools */;
+			targetProxy = 8E532014253303C9006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_952 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "PromiseKit::PromiseKit" /* PromiseKit */;
+			targetProxy = 8E532015253303C9006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_953 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "PathKit::PathKit" /* PathKit */;
+			targetProxy = 8E532016253303C9006AA460 /* PBXContainerItemProxy */;
+		};
+		OBJ_954 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "SwiftCLI::SwiftCLI" /* SwiftCLI */;
+			targetProxy = 8E532017253303C9006AA460 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		OBJ_1002 /* Debug */ = {
+		OBJ_1011 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.0.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.0.0";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
-		OBJ_1003 /* Release */ = {
+		OBJ_1012 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.0.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.0.0";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
-		OBJ_1007 /* Debug */ = {
+		OBJ_1016 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -3644,7 +3626,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_1008 /* Release */ = {
+		OBJ_1017 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -3668,25 +3650,25 @@
 			};
 			name = Release;
 		};
-		OBJ_1035 /* Debug */ = {
+		OBJ_1044 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2.0";
 				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
-		OBJ_1036 /* Release */ = {
+		OBJ_1045 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2.0";
 				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
-		OBJ_1040 /* Debug */ = {
+		OBJ_1049 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -3710,7 +3692,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_1041 /* Release */ = {
+		OBJ_1050 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -3734,25 +3716,25 @@
 			};
 			name = Release;
 		};
-		OBJ_1061 /* Debug */ = {
+		OBJ_1070 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2.0";
 				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
-		OBJ_1062 /* Release */ = {
+		OBJ_1071 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2.0";
 				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
-		OBJ_1066 /* Debug */ = {
+		OBJ_1075 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -3776,7 +3758,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_1067 /* Release */ = {
+		OBJ_1076 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -3800,25 +3782,25 @@
 			};
 			name = Release;
 		};
-		OBJ_1094 /* Debug */ = {
+		OBJ_1103 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.0.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.0.0";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
-		OBJ_1095 /* Release */ = {
+		OBJ_1104 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.0.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 4 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.0.0";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
-		OBJ_1099 /* Debug */ = {
+		OBJ_1108 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -3831,7 +3813,7 @@
 					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
 				);
 				INFOPLIST_FILE = Fugen.xcodeproj/Yams_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
@@ -3849,7 +3831,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_1100 /* Release */ = {
+		OBJ_1109 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -3862,7 +3844,7 @@
 					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
 				);
 				INFOPLIST_FILE = Fugen.xcodeproj/Yams_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
@@ -3880,31 +3862,31 @@
 			};
 			name = Release;
 		};
-		OBJ_1123 /* Debug */ = {
+		OBJ_1132 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
-		OBJ_1124 /* Release */ = {
+		OBJ_1133 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
-		OBJ_1129 /* Debug */ = {
+		OBJ_1138 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		OBJ_1130 /* Release */ = {
+		OBJ_1139 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
@@ -3961,7 +3943,7 @@
 			};
 			name = Release;
 		};
-		OBJ_524 /* Debug */ = {
+		OBJ_529 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
@@ -3976,7 +3958,7 @@
 					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
 				);
 				INFOPLIST_FILE = Fugen.xcodeproj/CYaml_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
@@ -3987,15 +3969,13 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
 				TARGET_NAME = CYaml;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
-		OBJ_525 /* Release */ = {
+		OBJ_530 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
@@ -4010,7 +3990,7 @@
 					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
 				);
 				INFOPLIST_FILE = Fugen.xcodeproj/CYaml_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
@@ -4021,14 +4001,13 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
-				SWIFT_VERSION = 5.0;
 				TARGET_NAME = CYaml;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};
-		OBJ_539 /* Debug */ = {
+		OBJ_544 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -4038,7 +4017,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Fugen.xcodeproj/DictionaryCoder_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
@@ -4056,7 +4035,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_540 /* Release */ = {
+		OBJ_545 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -4066,7 +4045,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Fugen.xcodeproj/DictionaryCoder_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				OTHER_CFLAGS = "$(inherited)";
@@ -4084,25 +4063,25 @@
 			};
 			name = Release;
 		};
-		OBJ_571 /* Debug */ = {
+		OBJ_576 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
-		OBJ_572 /* Release */ = {
+		OBJ_577 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
-		OBJ_577 /* Debug */ = {
+		OBJ_582 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4114,7 +4093,7 @@
 					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
 				);
 				INFOPLIST_FILE = Fugen.xcodeproj/Fugen_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_CFLAGS = "$(inherited)";
@@ -4130,7 +4109,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_578 /* Release */ = {
+		OBJ_583 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
@@ -4142,7 +4121,7 @@
 					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
 				);
 				INFOPLIST_FILE = Fugen.xcodeproj/Fugen_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx @executable_path";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_CFLAGS = "$(inherited)";
@@ -4158,37 +4137,37 @@
 			};
 			name = Release;
 		};
-		OBJ_785 /* Debug */ = {
+		OBJ_794 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
-		OBJ_786 /* Release */ = {
+		OBJ_795 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
-		OBJ_791 /* Debug */ = {
+		OBJ_800 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Debug;
 		};
-		OBJ_792 /* Release */ = {
+		OBJ_801 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
 			name = Release;
 		};
-		OBJ_798 /* Debug */ = {
+		OBJ_807 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
@@ -4202,9 +4181,9 @@
 					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
 				);
 				INFOPLIST_FILE = Fugen.xcodeproj/FugenTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -4216,7 +4195,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_799 /* Release */ = {
+		OBJ_808 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
@@ -4230,9 +4209,9 @@
 					"$(SRCROOT)/.build/checkouts/Yams/Sources/CYaml/include",
 				);
 				INFOPLIST_FILE = Fugen.xcodeproj/FugenTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -4244,7 +4223,7 @@
 			};
 			name = Release;
 		};
-		OBJ_826 /* Debug */ = {
+		OBJ_835 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -4254,7 +4233,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Fugen.xcodeproj/FugenTools_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_CFLAGS = "$(inherited)";
@@ -4272,7 +4251,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_827 /* Release */ = {
+		OBJ_836 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -4282,7 +4261,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Fugen.xcodeproj/FugenTools_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_CFLAGS = "$(inherited)";
@@ -4300,7 +4279,7 @@
 			};
 			name = Release;
 		};
-		OBJ_932 /* Debug */ = {
+		OBJ_941 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
@@ -4311,9 +4290,9 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Fugen.xcodeproj/FugenToolsTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -4325,7 +4304,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_933 /* Release */ = {
+		OBJ_942 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
@@ -4336,9 +4315,9 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Fugen.xcodeproj/FugenToolsTests_Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @loader_path/../Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -4350,7 +4329,7 @@
 			};
 			name = Release;
 		};
-		OBJ_947 /* Debug */ = {
+		OBJ_956 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -4374,7 +4353,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_948 /* Release */ = {
+		OBJ_957 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -4398,25 +4377,25 @@
 			};
 			name = Release;
 		};
-		OBJ_954 /* Debug */ = {
+		OBJ_963 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2.0";
 				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
-		OBJ_955 /* Release */ = {
+		OBJ_964 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 4.2 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 4.2.0";
 				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
-		OBJ_959 /* Debug */ = {
+		OBJ_968 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -4444,7 +4423,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_960 /* Release */ = {
+		OBJ_969 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -4472,25 +4451,25 @@
 			};
 			name = Release;
 		};
-		OBJ_980 /* Debug */ = {
+		OBJ_989 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
-		OBJ_981 /* Release */ = {
+		OBJ_990 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				LD = /usr/bin/true;
-				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -target x86_64-apple-macosx10.10 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
+				OTHER_SWIFT_FLAGS = "-swift-version 5 -I $(TOOLCHAIN_DIR)/usr/lib/swift/pm/4_2 -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -package-description-version 5.0.0";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
-		OBJ_985 /* Debug */ = {
+		OBJ_994 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -4514,7 +4493,7 @@
 			};
 			name = Debug;
 		};
-		OBJ_986 /* Release */ = {
+		OBJ_995 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
@@ -4541,92 +4520,92 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		OBJ_1001 /* Build configuration list for PBXNativeTarget "RainbowPackageDescription" */ = {
+		OBJ_1010 /* Build configuration list for PBXNativeTarget "RainbowPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_1002 /* Debug */,
-				OBJ_1003 /* Release */,
+				OBJ_1011 /* Debug */,
+				OBJ_1012 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_1006 /* Build configuration list for PBXNativeTarget "Stencil" */ = {
+		OBJ_1015 /* Build configuration list for PBXNativeTarget "Stencil" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_1007 /* Debug */,
-				OBJ_1008 /* Release */,
+				OBJ_1016 /* Debug */,
+				OBJ_1017 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_1034 /* Build configuration list for PBXNativeTarget "StencilPackageDescription" */ = {
+		OBJ_1043 /* Build configuration list for PBXNativeTarget "StencilPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_1035 /* Debug */,
-				OBJ_1036 /* Release */,
+				OBJ_1044 /* Debug */,
+				OBJ_1045 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_1039 /* Build configuration list for PBXNativeTarget "StencilSwiftKit" */ = {
+		OBJ_1048 /* Build configuration list for PBXNativeTarget "StencilSwiftKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_1040 /* Debug */,
-				OBJ_1041 /* Release */,
+				OBJ_1049 /* Debug */,
+				OBJ_1050 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_1060 /* Build configuration list for PBXNativeTarget "StencilSwiftKitPackageDescription" */ = {
+		OBJ_1069 /* Build configuration list for PBXNativeTarget "StencilSwiftKitPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_1061 /* Debug */,
-				OBJ_1062 /* Release */,
+				OBJ_1070 /* Debug */,
+				OBJ_1071 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_1065 /* Build configuration list for PBXNativeTarget "SwiftCLI" */ = {
+		OBJ_1074 /* Build configuration list for PBXNativeTarget "SwiftCLI" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_1066 /* Debug */,
-				OBJ_1067 /* Release */,
+				OBJ_1075 /* Debug */,
+				OBJ_1076 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_1093 /* Build configuration list for PBXNativeTarget "SwiftCLIPackageDescription" */ = {
+		OBJ_1102 /* Build configuration list for PBXNativeTarget "SwiftCLIPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_1094 /* Debug */,
-				OBJ_1095 /* Release */,
+				OBJ_1103 /* Debug */,
+				OBJ_1104 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_1098 /* Build configuration list for PBXNativeTarget "Yams" */ = {
+		OBJ_1107 /* Build configuration list for PBXNativeTarget "Yams" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_1099 /* Debug */,
-				OBJ_1100 /* Release */,
+				OBJ_1108 /* Debug */,
+				OBJ_1109 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_1122 /* Build configuration list for PBXNativeTarget "YamsPackageDescription" */ = {
+		OBJ_1131 /* Build configuration list for PBXNativeTarget "YamsPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_1123 /* Debug */,
-				OBJ_1124 /* Release */,
+				OBJ_1132 /* Debug */,
+				OBJ_1133 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_1128 /* Build configuration list for PBXAggregateTarget "fugen" */ = {
+		OBJ_1137 /* Build configuration list for PBXAggregateTarget "fugen" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_1129 /* Debug */,
-				OBJ_1130 /* Release */,
+				OBJ_1138 /* Debug */,
+				OBJ_1139 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -4640,128 +4619,128 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_523 /* Build configuration list for PBXNativeTarget "CYaml" */ = {
+		OBJ_528 /* Build configuration list for PBXNativeTarget "CYaml" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_524 /* Debug */,
-				OBJ_525 /* Release */,
+				OBJ_529 /* Debug */,
+				OBJ_530 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_538 /* Build configuration list for PBXNativeTarget "DictionaryCoder" */ = {
+		OBJ_543 /* Build configuration list for PBXNativeTarget "DictionaryCoder" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_539 /* Debug */,
-				OBJ_540 /* Release */,
+				OBJ_544 /* Debug */,
+				OBJ_545 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_570 /* Build configuration list for PBXNativeTarget "DictionaryCoderPackageDescription" */ = {
+		OBJ_575 /* Build configuration list for PBXNativeTarget "DictionaryCoderPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_571 /* Debug */,
-				OBJ_572 /* Release */,
+				OBJ_576 /* Debug */,
+				OBJ_577 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_576 /* Build configuration list for PBXNativeTarget "Fugen" */ = {
+		OBJ_581 /* Build configuration list for PBXNativeTarget "Fugen" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_577 /* Debug */,
-				OBJ_578 /* Release */,
+				OBJ_582 /* Debug */,
+				OBJ_583 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_784 /* Build configuration list for PBXNativeTarget "FugenPackageDescription" */ = {
+		OBJ_793 /* Build configuration list for PBXNativeTarget "FugenPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_785 /* Debug */,
-				OBJ_786 /* Release */,
+				OBJ_794 /* Debug */,
+				OBJ_795 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_790 /* Build configuration list for PBXAggregateTarget "FugenPackageTests" */ = {
+		OBJ_799 /* Build configuration list for PBXAggregateTarget "FugenPackageTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_791 /* Debug */,
-				OBJ_792 /* Release */,
+				OBJ_800 /* Debug */,
+				OBJ_801 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_797 /* Build configuration list for PBXNativeTarget "FugenTests" */ = {
+		OBJ_806 /* Build configuration list for PBXNativeTarget "FugenTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_798 /* Debug */,
-				OBJ_799 /* Release */,
+				OBJ_807 /* Debug */,
+				OBJ_808 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_825 /* Build configuration list for PBXNativeTarget "FugenTools" */ = {
+		OBJ_834 /* Build configuration list for PBXNativeTarget "FugenTools" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_826 /* Debug */,
-				OBJ_827 /* Release */,
+				OBJ_835 /* Debug */,
+				OBJ_836 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_931 /* Build configuration list for PBXNativeTarget "FugenToolsTests" */ = {
+		OBJ_940 /* Build configuration list for PBXNativeTarget "FugenToolsTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_932 /* Debug */,
-				OBJ_933 /* Release */,
+				OBJ_941 /* Debug */,
+				OBJ_942 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_946 /* Build configuration list for PBXNativeTarget "PathKit" */ = {
+		OBJ_955 /* Build configuration list for PBXNativeTarget "PathKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_947 /* Debug */,
-				OBJ_948 /* Release */,
+				OBJ_956 /* Debug */,
+				OBJ_957 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_953 /* Build configuration list for PBXNativeTarget "PathKitPackageDescription" */ = {
+		OBJ_962 /* Build configuration list for PBXNativeTarget "PathKitPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_954 /* Debug */,
-				OBJ_955 /* Release */,
+				OBJ_963 /* Debug */,
+				OBJ_964 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_958 /* Build configuration list for PBXNativeTarget "PromiseKit" */ = {
+		OBJ_967 /* Build configuration list for PBXNativeTarget "PromiseKit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_959 /* Debug */,
-				OBJ_960 /* Release */,
+				OBJ_968 /* Debug */,
+				OBJ_969 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_979 /* Build configuration list for PBXNativeTarget "PromiseKitPackageDescription" */ = {
+		OBJ_988 /* Build configuration list for PBXNativeTarget "PromiseKitPackageDescription" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_980 /* Debug */,
-				OBJ_981 /* Release */,
+				OBJ_989 /* Debug */,
+				OBJ_990 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		OBJ_984 /* Build configuration list for PBXNativeTarget "Rainbow" */ = {
+		OBJ_993 /* Build configuration list for PBXNativeTarget "Rainbow" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				OBJ_985 /* Debug */,
-				OBJ_986 /* Release */,
+				OBJ_994 /* Debug */,
+				OBJ_995 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Fugen.xcodeproj/xcshareddata/xcschemes/Fugen TextStyles.xcscheme
+++ b/Fugen.xcodeproj/xcshareddata/xcschemes/Fugen TextStyles.xcscheme
@@ -94,6 +94,10 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-o usingSystemFonts:false"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--accessToken 25961-4ac9fbc9-3bd8-4c43-bbe2-95e477f8a067"
             isEnabled = "YES">
          </CommandLineArgument>
@@ -111,10 +115,6 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-d FugenDemo/Generated/TextStyle.swift"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-o publicAccess:true"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Fugen.xcodeproj/xcshareddata/xcschemes/Fugen-Package.xcscheme
+++ b/Fugen.xcodeproj/xcshareddata/xcschemes/Fugen-Package.xcscheme
@@ -46,9 +46,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Fugen::FugenToolsTests"
-               BuildableName = "FugenToolsTests.xctest"
-               BlueprintName = "FugenToolsTests"
+               BlueprintIdentifier = "Fugen::FugenTests"
+               BuildableName = "FugenTests.xctest"
+               BlueprintName = "FugenTests"
                ReferencedContainer = "container:Fugen.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -56,9 +56,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Fugen::FugenTests"
-               BuildableName = "FugenTests.xctest"
-               BlueprintName = "FugenTests"
+               BlueprintIdentifier = "Fugen::FugenToolsTests"
+               BuildableName = "FugenToolsTests.xctest"
+               BlueprintName = "FugenToolsTests"
                ReferencedContainer = "container:Fugen.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Key  | Type | Default value | Description
 `colorTypeName` | String | UIColor | Color type name. If the target platform is macOS, specify `NSColor`.
 `fontTypeName` | String | UIFont | Font type name. If the target platform is macOS, specify `NSFont`.
 `publicAccess` | Boolean | false | Adds `public` access modifier to the declarations in the generated file.
+usingSystemFonts | Boolean | false | If text style has system font (**SFProText** or **SFProDisplay**), then `font` property will be using `systemFont(ofSize:weight:)` method. 
 
 ## Shadow styles
 

--- a/Sources/Fugen/Dependencies.swift
+++ b/Sources/Fugen/Dependencies.swift
@@ -71,7 +71,9 @@ enum Dependencies {
         StencilColorRGBInfoFilter(contextCoder: templateContextCoder),
         StencilColorRGBAInfoFilter(contextCoder: templateContextCoder),
         StencilColorInfoFilter(contextCoder: templateContextCoder),
-        StencilFontInfoFilter(contextCoder: templateContextCoder)
+        StencilFontInfoFilter(contextCoder: templateContextCoder),
+        StencilFontInitializerModificator(contextCoder: templateContextCoder),
+        StencilFontSystemFilter(contextCoder: templateContextCoder)
     ]
 
     static let templateRenderer: TemplateRenderer = DefaultTemplateRenderer(

--- a/Sources/Fugen/Models/Font.swift
+++ b/Sources/Fugen/Models/Font.swift
@@ -9,3 +9,20 @@ struct Font: Codable, Hashable {
     let weight: Double
     let size: Double
 }
+
+extension Font {
+
+    // MARK: - Instance Properties
+
+    var isSystemFont: Bool {
+        name.contains(String.textSystemFontName) || name.contains(String.displaySystemFontName)
+    }
+}
+
+private extension String {
+
+    // MARK: - Type Properties
+
+    static let textSystemFontName = "SFProText"
+    static let displaySystemFontName = "SFProDisplay"
+}

--- a/Sources/Fugen/Render/StencilExtensions/Font/StencilFontInitializerModificator.swift
+++ b/Sources/Fugen/Render/StencilExtensions/Font/StencilFontInitializerModificator.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#else
+import AppKit
+#endif
+
+final class StencilFontInitializerModificator: StencilFontModificator {
+
+    // MARK: - Type Properties
+
+    private static let validWeights = [
+        "ultraLight",
+        "thin",
+        "light",
+        "regular",
+        "medium",
+        "semibold",
+        "bold",
+        "heavy",
+        "black"
+    ]
+
+    // MARK: - Instance Properties
+
+    let name = "initializer"
+
+    let contextCoder: TemplateContextCoder
+
+    // MARK: - Initializers
+
+    init(contextCoder: TemplateContextCoder) {
+        self.contextCoder = contextCoder
+    }
+
+    // MARK: - Instance Methods
+
+    private func validatedWeight(rawWeight: String?) -> String? {
+        guard let rawWeight = rawWeight?.lowercased() else {
+            return nil
+        }
+
+        return Self.validWeights.first(where: { rawWeight == $0 })
+    }
+
+    // MARK: -
+
+    func modify(font: Font, withArguments arguments: [Any?]) throws -> String {
+        guard font.isSystemFont, try parseBool(from: arguments, at: .usingSystemFontArgument) else {
+            return "(name: \"\(font.name)\", size: \(font.size))"
+        }
+
+        let weight = validatedWeight(rawWeight: font.name.components(separatedBy: "-").last) ?? .defaultWeight
+
+        return ".systemFont(ofSize: \(font.size), weight: .\(weight))"
+    }
+}
+
+private extension String {
+
+    // MARK: - Type Properties
+
+    static let defaultWeight = "regular"
+}
+
+private extension Int {
+
+    // MARK: - Type Properties
+
+    static let usingSystemFontArgument = 0
+}

--- a/Sources/Fugen/Render/StencilExtensions/Font/StencilFontInitializerModificator.swift
+++ b/Sources/Fugen/Render/StencilExtensions/Font/StencilFontInitializerModificator.swift
@@ -44,10 +44,18 @@ final class StencilFontInitializerModificator: StencilFontModificator {
         return Self.validWeights.first(where: { rawWeight == $0 })
     }
 
+    private func usingSystemFonts(from arguments: [Any?]) throws -> Bool {
+        guard let usingSystemFonts = arguments.first else {
+            throw StencilModificatorError(code: .invalidArguments(arguments), filter: name)
+        }
+
+        return usingSystemFonts as? Bool ?? false
+    }
+
     // MARK: -
 
     func modify(font: Font, withArguments arguments: [Any?]) throws -> String {
-        guard font.isSystemFont, try parseBool(from: arguments, at: .usingSystemFontArgument) else {
+        guard font.isSystemFont, try usingSystemFonts(from: arguments) else {
             return "(name: \"\(font.name)\", size: \(font.size))"
         }
 
@@ -62,11 +70,4 @@ private extension String {
     // MARK: - Type Properties
 
     static let defaultWeight = "regular"
-}
-
-private extension Int {
-
-    // MARK: - Type Properties
-
-    static let usingSystemFontArgument = 0
 }

--- a/Sources/Fugen/Render/StencilExtensions/Font/StencilFontInitializerModificator.swift
+++ b/Sources/Fugen/Render/StencilExtensions/Font/StencilFontInitializerModificator.swift
@@ -41,7 +41,7 @@ final class StencilFontInitializerModificator: StencilFontModificator {
             return nil
         }
 
-        return Self.validWeights.first(where: { rawWeight == $0 })
+        return Self.validWeights.first { rawWeight == $0 }
     }
 
     private func usingSystemFonts(from arguments: [Any?]) throws -> Bool {

--- a/Sources/Fugen/Render/StencilExtensions/Font/StencilFontModificator.swift
+++ b/Sources/Fugen/Render/StencilExtensions/Font/StencilFontModificator.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+protocol StencilFontModificator: StencilModificator where Input == [String: Any], Output == FontModificatorOutput {
+
+    // MARK: - Nested Types
+
+    associatedtype FontModificatorOutput
+
+    // MARK: - Instance Properties
+
+    var contextCoder: TemplateContextCoder { get }
+
+    // MARK: - Instance Methods
+
+    func modify(font: Font, withArguments arguments: [Any?]) throws -> FontModificatorOutput
+}
+
+extension StencilFontModificator {
+
+    // MARK: - Instance Methods
+
+    func modify(input: [String: Any], withArguments arguments: [Any?]) throws -> FontModificatorOutput {
+        guard let font = try? contextCoder.decode(Font.self, from: input) else {
+            throw StencilModificatorError(code: .invalidValue(input), filter: name)
+        }
+
+        return try modify(font: font, withArguments: arguments)
+    }
+}

--- a/Sources/Fugen/Render/StencilExtensions/Font/StencilFontSystemFilter.swift
+++ b/Sources/Fugen/Render/StencilExtensions/Font/StencilFontSystemFilter.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+final class StencilFontSystemFilter: StencilFontFilter {
+
+    // MARK: - Instance Properties
+
+    let name = "isSystemFont"
+
+    let contextCoder: TemplateContextCoder
+
+    // MARK: - Initializers
+
+    init(contextCoder: TemplateContextCoder) {
+        self.contextCoder = contextCoder
+    }
+
+    // MARK: - Instance Methods
+
+    func filter(font: Font) throws -> Bool {
+        font.isSystemFont
+    }
+}

--- a/Sources/Fugen/Render/StencilExtensions/StencilModificator.swift
+++ b/Sources/Fugen/Render/StencilExtensions/StencilModificator.swift
@@ -1,0 +1,58 @@
+//
+//  StencilModificator.swift
+//  Fugen
+//
+//  Created by Timur Shafigullin on 05.10.2020.
+//
+
+import Foundation
+import FugenTools
+
+protocol StencilModificator: StencilExtension {
+
+    // MARK: - Nested Types
+
+    associatedtype Input
+    associatedtype Output
+
+    // MARK: - Instance Methods
+
+    func modify(input: Input, withArguments arguments: [Any?]) throws -> Output
+}
+
+extension StencilModificator {
+
+    // MARK: - Instance Methods
+
+    func register(in extensionRegistry: ExtensionRegistry) {
+        extensionRegistry.registerFilter(name, filter: { value, parameters in
+            guard let input = value as? Input else {
+                throw StencilModificatorError(code: .invalidValue(value), filter: name)
+            }
+
+            return try self.modify(input: input, withArguments: parameters)
+        })
+    }
+}
+
+extension StencilModificator {
+
+    // MARK: - Instance Methods
+
+    func parseBool(from arguments: [Any?], at index: Int = 0) throws -> Bool {
+        guard let rawArgument = arguments[safe: index] as? String else {
+            throw StencilModificatorError(code: .invalidArguments(arguments), filter: name)
+        }
+
+        switch rawArgument.lowercased() {
+        case "false", "no", "0":
+            return false
+
+        case "true", "yes", "1":
+            return true
+
+        default:
+            throw StencilModificatorError(code: .invalidArguments(arguments), filter: name)
+        }
+    }
+}

--- a/Sources/Fugen/Render/StencilExtensions/StencilModificator.swift
+++ b/Sources/Fugen/Render/StencilExtensions/StencilModificator.swift
@@ -34,25 +34,3 @@ extension StencilModificator {
         })
     }
 }
-
-extension StencilModificator {
-
-    // MARK: - Instance Methods
-
-    func parseBool(from arguments: [Any?], at index: Int = 0) throws -> Bool {
-        guard let rawArgument = arguments[safe: index] as? String else {
-            throw StencilModificatorError(code: .invalidArguments(arguments), filter: name)
-        }
-
-        switch rawArgument.lowercased() {
-        case "false", "no", "0":
-            return false
-
-        case "true", "yes", "1":
-            return true
-
-        default:
-            throw StencilModificatorError(code: .invalidArguments(arguments), filter: name)
-        }
-    }
-}

--- a/Sources/Fugen/Render/StencilExtensions/StencilModificator.swift
+++ b/Sources/Fugen/Render/StencilExtensions/StencilModificator.swift
@@ -1,10 +1,3 @@
-//
-//  StencilModificator.swift
-//  Fugen
-//
-//  Created by Timur Shafigullin on 05.10.2020.
-//
-
 import Foundation
 import FugenTools
 
@@ -25,12 +18,12 @@ extension StencilModificator {
     // MARK: - Instance Methods
 
     func register(in extensionRegistry: ExtensionRegistry) {
-        extensionRegistry.registerFilter(name, filter: { value, parameters in
+        extensionRegistry.registerFilter(name) { value, parameters in
             guard let input = value as? Input else {
                 throw StencilModificatorError(code: .invalidValue(value), filter: name)
             }
 
             return try self.modify(input: input, withArguments: parameters)
-        })
+        }
     }
 }

--- a/Sources/Fugen/Render/StencilExtensions/StencilModificatorError.swift
+++ b/Sources/Fugen/Render/StencilExtensions/StencilModificatorError.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+struct StencilModificatorError: Error, CustomStringConvertible {
+
+    // MARK: - Nested Types
+
+    enum Code {
+        case invalidValue(_ value: Any?)
+        case invalidArguments(_ argument: [Any?])
+    }
+
+    // MARK: - Instance Properties
+
+    let code: Code
+    let filter: String
+
+    // MARK: - Instance Properties
+
+    var description: String {
+        switch code {
+        case let .invalidValue(value):
+            let valueDescription = value.map(String.init(describing:)) ?? "nil"
+
+            return "Stencil filter '\(filter)' cannot be used for value: \(valueDescription)"
+
+        case let .invalidArguments(arguments):
+            let argumentDescriptions = arguments.compactMap { $0 }.map(String.init(describing:))
+
+            return "Stencil filter '\(filter)' was called with an invalid arguments: \(argumentDescriptions)"
+        }
+    }
+}

--- a/Templates/TextStyles.stencil
+++ b/Templates/TextStyles.stencil
@@ -6,7 +6,6 @@
 {% set colorTypeName %}{{ options.colorTypeName|default:"UIColor" }}{% endset %}
 {% set strikethroughStyle %}{{ options.strikethroughStyle|default:"single" }}{% endset %}
 {% set underlineStyle %}{{ options.underlineStyle|default:"single" }}{% endset %}
-{% set usingSystemFonts %}{{ options.usingSystemFonts|default:"false" }}{% endset %}
 {% macro propertyName name %}{{ name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords }}{% endmacro %}
 {% set optionalFontTypeName %}{{ fontTypeName }}?{% endset %}
 {% set optionalColorTypeName %}{{ colorTypeName }}?{% endset %}
@@ -64,7 +63,7 @@ import AppKit
     /// Line height: {{ style.lineHeight|default:"default" }}
     /// Letter spacing: {{ style.letterSpacing|default:"default" }}
     {{ accessModifier }} static let {% call propertyName style.name %} = {{ styleTypeName }}(
-        font: {{ fontTypeName }}{{ style.font|initializer:usingSystemFonts }},
+        font: {{ fontTypeName }}{{ style.font|initializer:options.usingSystemFonts }},
         color: {{ colorTypeName }}(
             red: {{ style.color.color.red }},
             green: {{ style.color.color.green }},
@@ -84,7 +83,7 @@ import AppKit
 
     {{ accessModifier }} static func validate() throws {
         {% for style in textStyles %}
-        {% if not ( usingSystemFonts and style.font|isSystemFont ) %}
+        {% if not ( options.usingSystemFonts and style.font|isSystemFont ) %}
         guard {{ fontTypeName }}(name: "{{ style.font.name }}", size: {{ style.font.size }}) != nil else {
             throw ValidationError.fontNotFound(name: "{{ style.font.name }}", size: {{ style.font.size }})
         }

--- a/Templates/TextStyles.stencil
+++ b/Templates/TextStyles.stencil
@@ -6,6 +6,7 @@
 {% set colorTypeName %}{{ options.colorTypeName|default:"UIColor" }}{% endset %}
 {% set strikethroughStyle %}{{ options.strikethroughStyle|default:"single" }}{% endset %}
 {% set underlineStyle %}{{ options.underlineStyle|default:"single" }}{% endset %}
+{% set usingSystemFonts %}{{ options.usingSystemFonts|default:"false" }}{% endset %}
 {% macro propertyName name %}{{ name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords }}{% endmacro %}
 {% set optionalFontTypeName %}{{ fontTypeName }}?{% endset %}
 {% set optionalColorTypeName %}{{ colorTypeName }}?{% endset %}
@@ -63,7 +64,7 @@ import AppKit
     /// Line height: {{ style.lineHeight|default:"default" }}
     /// Letter spacing: {{ style.letterSpacing|default:"default" }}
     {{ accessModifier }} static let {% call propertyName style.name %} = {{ styleTypeName }}(
-        font: {{ fontTypeName }}(name: "{{ style.font.name }}", size: {{ style.font.size }}),
+        font: {{ fontTypeName }}{{ style.font|initializer:usingSystemFonts }},
         color: {{ colorTypeName }}(
             red: {{ style.color.color.red }},
             green: {{ style.color.color.green }},
@@ -83,10 +84,12 @@ import AppKit
 
     {{ accessModifier }} static func validate() throws {
         {% for style in textStyles %}
+        {% if not ( usingSystemFonts and style.font|isSystemFont ) %}
         guard {{ fontTypeName }}(name: "{{ style.font.name }}", size: {{ style.font.size }}) != nil else {
             throw ValidationError.fontNotFound(name: "{{ style.font.name }}", size: {{ style.font.size }})
         }
 
+        {% endif %}
         {% endfor %}
         print("All text styles are valid")
     }


### PR DESCRIPTION
New template option for text style generation - `usingSystemFont`:
```yaml
textStyles:
  file:
    key: ...
    includedNodes:
      - ...
  destination: ...
  templateOptions:
    usingSystemFonts: true
```

This option generate text style with fonts **SFProText** and **SFProDisplay** using `systemFont(ofSize:weight:)` function.

For example, generated text style with enabled option:
```swift
public static let caption = TextStyle(
    font: UIFont.systemFont(ofSize: 13.0, weight: .light),
    ...
)
```

With disabled option or if omitted:
```swift
public static let caption = TextStyle(
    font: UIFont(name: "SFProDisplay-Light", size: 13.0),
    ...
)
```