### PR TITLE
Use absolute bounds setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,8 @@ The default format is `pdf`.
 The default scaling factor is 1, so the image will have the original size.
 - `onlyExportables`: renders only exportable components.
 The default value is `false`.
+- `useAbsoluteBounds`: uses full dimensions of the node.
+The default value is `false`.
 
 
 Sample configuration:
@@ -418,6 +420,7 @@ images:
   assets: Sources/Assets.xcassets/Images
   destination: Sources/Images.swift
   onlyExportables: true
+  useAbsoluteBounds true
   templateOptions:
     publicAccess: true
 ```
@@ -431,6 +434,11 @@ allows to filter out the components that should not render images in Figma file.
 If you want to export only those components
 that have [export settings](https://help.figma.com/hc/en-us/articles/360040028114-Getting-Started-with-Exports) in Figma,
 set the `onlyExportables` flag to `true`.
+
+#### Use absolute bounds
+By default Fugen exports the images using only space that is actually occupied by them, so if the node has extra space 
+around, it will be cropped. If you want to preserve this space set the `useAbsoluteBounds` to `true`. 
+See [Image Endpoint Description](https://www.figma.com/developers/api#get-images-endpoint) for details.
 
 #### Xcode-assets
 It's recommended to specify the path to a subfolder inside the Xcode-assets folder in the `assets` parameter,

--- a/Sources/Fugen/Commands/ImagesCommand.swift
+++ b/Sources/Fugen/Commands/ImagesCommand.swift
@@ -125,6 +125,15 @@ final class ImagesCommand: AsyncExecutableCommand, GenerationConfigurableCommand
         defaultValue: false
     )
 
+    let useAbsoluteBounds = Flag(
+        "--useAbsoluteBounds",
+        description: """
+            Use the full dimensions of the node.
+            By default, images will omit empty space or crop.
+            """,
+        defaultValue: false
+    )
+
     // MARK: - Initializers
 
     init(generator: ImagesGenerator) {
@@ -167,7 +176,8 @@ final class ImagesCommand: AsyncExecutableCommand, GenerationConfigurableCommand
             resources: resources.value,
             format: resolveImageFormat(),
             scales: resolveImageScales(),
-            onlyExportables: onlyExportables.value
+            onlyExportables: onlyExportables.value,
+            useAbsoluteBounds: useAbsoluteBounds.value
         )
     }
 

--- a/Sources/Fugen/Commands/ImagesCommand.swift
+++ b/Sources/Fugen/Commands/ImagesCommand.swift
@@ -128,7 +128,7 @@ final class ImagesCommand: AsyncExecutableCommand, GenerationConfigurableCommand
     let useAbsoluteBounds = Flag(
         "--useAbsoluteBounds",
         description: """
-            Use the full dimensions of the node.
+            Use full dimensions of the node.
             By default, images will omit empty space or crop.
             """,
         defaultValue: false

--- a/Sources/Fugen/Generators/Images/DefaultImagesGenerator.swift
+++ b/Sources/Fugen/Generators/Images/DefaultImagesGenerator.swift
@@ -60,7 +60,8 @@ private extension ImagesConfiguration {
             scales: scales,
             assets: assets,
             resources: resources,
-            onlyExportables: onlyExportables
+            onlyExportables: onlyExportables,
+            useAbsoluteBounds: useAbsoluteBounds
         )
     }
 }

--- a/Sources/Fugen/Models/Configuration/ImagesConfiguration.swift
+++ b/Sources/Fugen/Models/Configuration/ImagesConfiguration.swift
@@ -10,6 +10,7 @@ struct ImagesConfiguration: Decodable {
         case format
         case scales
         case onlyExportables
+        case useAbsoluteBounds
     }
 
     // MARK: - Instance Properties
@@ -20,6 +21,7 @@ struct ImagesConfiguration: Decodable {
     let format: ImageFormat
     let scales: [ImageScale]
     let onlyExportables: Bool
+    let useAbsoluteBounds: Bool
 
     // MARK: - Initializers
 
@@ -29,7 +31,8 @@ struct ImagesConfiguration: Decodable {
         resources: String?,
         format: ImageFormat,
         scales: [ImageScale],
-        onlyExportables: Bool
+        onlyExportables: Bool,
+        useAbsoluteBounds: Bool
     ) {
         self.generatation = generatation
         self.assets = assets
@@ -37,6 +40,7 @@ struct ImagesConfiguration: Decodable {
         self.format = format
         self.scales = scales
         self.onlyExportables = onlyExportables
+        self.useAbsoluteBounds = useAbsoluteBounds
     }
 
     init(from decoder: Decoder) throws {
@@ -48,6 +52,7 @@ struct ImagesConfiguration: Decodable {
         format = try container.decodeIfPresent(forKey: .format) ?? .pdf
         scales = try container.decodeIfPresent(forKey: .scales) ?? [.none]
         onlyExportables = try container.decodeIfPresent(forKey: .onlyExportables) ?? false
+        useAbsoluteBounds = try container.decodeIfPresent(forKey: .useAbsoluteBounds) ?? false
 
         generatation = try GenerationConfiguration(from: decoder)
     }
@@ -61,7 +66,8 @@ struct ImagesConfiguration: Decodable {
             resources: resources,
             format: format,
             scales: scales,
-            onlyExportables: onlyExportables
+            onlyExportables: onlyExportables,
+            useAbsoluteBounds: useAbsoluteBounds
         )
     }
 }

--- a/Sources/Fugen/Models/Parameters/ImagesParameters.swift
+++ b/Sources/Fugen/Models/Parameters/ImagesParameters.swift
@@ -9,4 +9,5 @@ struct ImagesParameters {
     let assets: String?
     let resources: String?
     let onlyExportables: Bool
+    let useAbsoluteBounds: Bool
 }

--- a/Sources/Fugen/Providers/FigmaAPI/DefaultFigmaAPIProvider.swift
+++ b/Sources/Fugen/Providers/FigmaAPI/DefaultFigmaAPIProvider.swift
@@ -19,8 +19,7 @@ final class DefaultFigmaAPIProvider: FigmaAPIProvider {
     init(httpService: FigmaHTTPService) {
         self.httpService = httpService
 
-        let urlEncoder = URLEncoder()
-        urlEncoder.boolEncodingStrategy = .literal
+        let urlEncoder = URLEncoder(boolEncodingStrategy: .literal)
         let jsonEncoder = JSONEncoder()
         let jsonDecoder = JSONDecoder()
 

--- a/Sources/Fugen/Providers/FigmaAPI/DefaultFigmaAPIProvider.swift
+++ b/Sources/Fugen/Providers/FigmaAPI/DefaultFigmaAPIProvider.swift
@@ -20,6 +20,7 @@ final class DefaultFigmaAPIProvider: FigmaAPIProvider {
         self.httpService = httpService
 
         let urlEncoder = URLEncoder()
+        urlEncoder.boolEncodingStrategy = .literal
         let jsonEncoder = JSONEncoder()
         let jsonDecoder = JSONDecoder()
 

--- a/Sources/Fugen/Providers/FigmaAPI/Routes/FigmaAPIImagesRoute.swift
+++ b/Sources/Fugen/Providers/FigmaAPI/Routes/FigmaAPIImagesRoute.swift
@@ -28,7 +28,8 @@ struct FigmaAPIImagesRoute: FigmaAPIRoute {
         format: FigmaImageFormat? = nil,
         scale: Double? = nil,
         svgIncludeID: Bool? = nil,
-        svgSimplifyStroke: Bool? = nil
+        svgSimplifyStroke: Bool? = nil,
+        useAbsoluteBounds: Bool? = nil
     ) {
         self.accessToken = accessToken
         self.fileKey = fileKey
@@ -39,7 +40,8 @@ struct FigmaAPIImagesRoute: FigmaAPIRoute {
             format: format?.rawValue.lowercased(),
             scale: scale,
             svgIncludeID: svgIncludeID,
-            svgSimplifyStroke: svgSimplifyStroke
+            svgSimplifyStroke: svgSimplifyStroke,
+            useAbsolutBounds: useAbsoluteBounds
         )
     }
 }

--- a/Sources/Fugen/Providers/FigmaAPI/Routes/FigmaAPIImagesRouteQueryParameters.swift
+++ b/Sources/Fugen/Providers/FigmaAPI/Routes/FigmaAPIImagesRouteQueryParameters.swift
@@ -11,6 +11,7 @@ struct FigmaAPIImagesRouteQueryParameters: Encodable {
         case scale
         case svgIncludeID = "svg_include_id"
         case svgSimplifyStroke = "svg_simplify_stroke"
+        case useAbsolutBounds = "use_absolute_bounds"
     }
 
     // MARK: - Instance Properties
@@ -21,4 +22,5 @@ struct FigmaAPIImagesRouteQueryParameters: Encodable {
     let scale: Double?
     let svgIncludeID: Bool?
     let svgSimplifyStroke: Bool?
+    let useAbsolutBounds: Bool?
 }

--- a/Sources/Fugen/Providers/Images/DefaultImagesProvider.swift
+++ b/Sources/Fugen/Providers/Images/DefaultImagesProvider.swift
@@ -124,7 +124,8 @@ final class DefaultImagesProvider: ImagesProvider {
                 of: file,
                 nodes: nodes,
                 format: parameters.format,
-                scales: parameters.scales
+                scales: parameters.scales,
+                useAbsoluteBounds: parameters.useAbsoluteBounds
             )
         }.then { nodes in
             firstly {

--- a/Sources/Fugen/Providers/Images/Render/DefaultImageRenderProvider.swift
+++ b/Sources/Fugen/Providers/Images/Render/DefaultImageRenderProvider.swift
@@ -54,7 +54,8 @@ final class DefaultImageRenderProvider: ImageRenderProvider {
         of file: FileParameters,
         nodes: [ImageNode],
         format: ImageFormat,
-        scale: ImageScale
+        scale: ImageScale,
+        useAbsoluteBounds: Bool
     ) -> Promise<[ImageNode: URL]> {
         let route = FigmaAPIImagesRoute(
             accessToken: file.accessToken,
@@ -62,7 +63,8 @@ final class DefaultImageRenderProvider: ImageRenderProvider {
             fileVersion: file.version,
             nodeIDs: nodes.map { $0.id },
             format: format.figmaFormat,
-            scale: scale.figmaScale
+            scale: scale.figmaScale,
+            useAbsoluteBounds: useAbsoluteBounds
         )
 
         return firstly {
@@ -78,16 +80,18 @@ final class DefaultImageRenderProvider: ImageRenderProvider {
         of file: FileParameters,
         nodes: [ImageNode],
         format: ImageFormat,
-        scales: [ImageScale]
+        scales: [ImageScale],
+        useAbsoluteBounds: Bool
     ) -> Promise<[ImageRenderedNode]> {
         guard !nodes.isEmpty else {
             return .value([])
         }
 
         let promises = scales.map { scale in
-            renderImages(of: file, nodes: nodes, format: format, scale: scale).map { imageURLs in
-                (scale: scale, imageURLs: imageURLs)
-            }
+            renderImages(of: file, nodes: nodes, format: format, scale: scale, useAbsoluteBounds: useAbsoluteBounds)
+                .map { imageURLs in
+                    (scale: scale, imageURLs: imageURLs)
+                }
         }
 
         return firstly {

--- a/Sources/Fugen/Providers/Images/Render/ImageRenderProvider.swift
+++ b/Sources/Fugen/Providers/Images/Render/ImageRenderProvider.swift
@@ -9,6 +9,7 @@ protocol ImageRenderProvider {
         of file: FileParameters,
         nodes: [ImageNode],
         format: ImageFormat,
-        scales: [ImageScale]
+        scales: [ImageScale],
+        useAbsoluteBounds: Bool
     ) -> Promise<[ImageRenderedNode]>
 }


### PR DESCRIPTION
Currently Fugen exports images ignoring full dimensions of the corresponding
nodes, so their sizes may differ from those seen in Figma. This PR is adding a
setting that provides the ability to change this behaviour.

Changes:

- Added the ability to set `useAbsoluteBounds` Figma API flag for images export
    within config file and with `--useAbsoluteBounds` command line argument.

    This setting gives the ability to export images with full dimensions of the
    node. The details about this flag can be found here
    <https://www.figma.com/developers/api#get-images-endpoint>.

- `URLEncoder` in `DefaultFigmaAPIProvider` was configured to use `.literal`
    boolean encoding strategy, because the it's critical to use literal booleans
    with Figma API.

- README updated with info about this flag.
