### PR TITLE
Added support of preserve vector data flag for Xcode assets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,8 @@ The default scaling factor is 1, so the image will have the original size.
 The default value is `false`.
 - `useAbsoluteBounds`: uses full dimensions of the node.
 The default value is `false`.
+- `preserveVectorData`: sets `Preserve Vector Data` flag in Xcode assets.
+The default value is `false`.
 
 
 Sample configuration:

--- a/Sources/Fugen/Commands/ImagesCommand.swift
+++ b/Sources/Fugen/Commands/ImagesCommand.swift
@@ -134,6 +134,15 @@ final class ImagesCommand: AsyncExecutableCommand, GenerationConfigurableCommand
         defaultValue: false
     )
 
+    let preserveVectorData = Flag(
+        "--preserveVectorData",
+        description: """
+        Set preserve vector data flag in Xcode assets.
+        By default, Xcode assets will be generated without vector data preserving.
+        """,
+        defaultValue: false
+    )
+
     // MARK: - Initializers
 
     init(generator: ImagesGenerator) {
@@ -177,7 +186,8 @@ final class ImagesCommand: AsyncExecutableCommand, GenerationConfigurableCommand
             format: resolveImageFormat(),
             scales: resolveImageScales(),
             onlyExportables: onlyExportables.value,
-            useAbsoluteBounds: useAbsoluteBounds.value
+            useAbsoluteBounds: useAbsoluteBounds.value,
+            preserveVectorData: preserveVectorData.value
         )
     }
 

--- a/Sources/Fugen/Generators/Images/DefaultImagesGenerator.swift
+++ b/Sources/Fugen/Generators/Images/DefaultImagesGenerator.swift
@@ -61,7 +61,8 @@ private extension ImagesConfiguration {
             assets: assets,
             resources: resources,
             onlyExportables: onlyExportables,
-            useAbsoluteBounds: useAbsoluteBounds
+            useAbsoluteBounds: useAbsoluteBounds,
+            preserveVectorData: preserveVectorData
         )
     }
 }

--- a/Sources/Fugen/Models/Configuration/ImagesConfiguration.swift
+++ b/Sources/Fugen/Models/Configuration/ImagesConfiguration.swift
@@ -11,6 +11,7 @@ struct ImagesConfiguration: Decodable {
         case scales
         case onlyExportables
         case useAbsoluteBounds
+        case preserveVectorData
     }
 
     // MARK: - Instance Properties
@@ -22,6 +23,7 @@ struct ImagesConfiguration: Decodable {
     let scales: [ImageScale]
     let onlyExportables: Bool
     let useAbsoluteBounds: Bool
+    let preserveVectorData: Bool
 
     // MARK: - Initializers
 
@@ -32,7 +34,8 @@ struct ImagesConfiguration: Decodable {
         format: ImageFormat,
         scales: [ImageScale],
         onlyExportables: Bool,
-        useAbsoluteBounds: Bool
+        useAbsoluteBounds: Bool,
+        preserveVectorData: Bool
     ) {
         self.generatation = generatation
         self.assets = assets
@@ -41,6 +44,7 @@ struct ImagesConfiguration: Decodable {
         self.scales = scales
         self.onlyExportables = onlyExportables
         self.useAbsoluteBounds = useAbsoluteBounds
+        self.preserveVectorData = preserveVectorData
     }
 
     init(from decoder: Decoder) throws {
@@ -53,6 +57,7 @@ struct ImagesConfiguration: Decodable {
         scales = try container.decodeIfPresent(forKey: .scales) ?? [.none]
         onlyExportables = try container.decodeIfPresent(forKey: .onlyExportables) ?? false
         useAbsoluteBounds = try container.decodeIfPresent(forKey: .useAbsoluteBounds) ?? false
+        preserveVectorData = try container.decodeIfPresent(forKey: .preserveVectorData) ?? false
 
         generatation = try GenerationConfiguration(from: decoder)
     }
@@ -67,7 +72,8 @@ struct ImagesConfiguration: Decodable {
             format: format,
             scales: scales,
             onlyExportables: onlyExportables,
-            useAbsoluteBounds: useAbsoluteBounds
+            useAbsoluteBounds: useAbsoluteBounds,
+            preserveVectorData: preserveVectorData
         )
     }
 }

--- a/Sources/Fugen/Models/Images/ImageAsset.swift
+++ b/Sources/Fugen/Models/Images/ImageAsset.swift
@@ -6,4 +6,5 @@ struct ImageAsset: Encodable, Hashable {
 
     let name: String
     let filePaths: [ImageScale: String]
+    let preserveVectorData: Bool
 }

--- a/Sources/Fugen/Models/Parameters/ImagesParameters.swift
+++ b/Sources/Fugen/Models/Parameters/ImagesParameters.swift
@@ -10,4 +10,5 @@ struct ImagesParameters {
     let resources: String?
     let onlyExportables: Bool
     let useAbsoluteBounds: Bool
+    let preserveVectorData: Bool
 }

--- a/Sources/Fugen/Providers/Images/Assets/ImageAssetsProvider.swift
+++ b/Sources/Fugen/Providers/Images/Assets/ImageAssetsProvider.swift
@@ -8,6 +8,7 @@ protocol ImageAssetsProvider {
     func saveImages(
         nodes: [ImageRenderedNode],
         format: ImageFormat,
+        preserveVectorData: Bool,
         in folderPath: String
     ) -> Promise<[ImageRenderedNode: ImageAsset]>
 }

--- a/Sources/Fugen/Providers/Images/DefaultImagesProvider.swift
+++ b/Sources/Fugen/Providers/Images/DefaultImagesProvider.swift
@@ -85,10 +85,16 @@ final class DefaultImagesProvider: ImagesProvider {
     private func saveAssetImagesIfNeeded(
         nodes: [ImageRenderedNode],
         format: ImageFormat,
+        preserveVectorData: Bool,
         in assets: String?
     ) -> Promise<[ImageRenderedNode: ImageAsset]> {
         return assets.map { folderPath in
-            imageAssetsProvider.saveImages(nodes: nodes, format: format, in: folderPath)
+            imageAssetsProvider.saveImages(
+                nodes: nodes,
+                format: format,
+                preserveVectorData: preserveVectorData,
+                in: folderPath
+            )
         } ?? .value([:])
     }
 
@@ -133,6 +139,7 @@ final class DefaultImagesProvider: ImagesProvider {
                     fulfilled: self.saveAssetImagesIfNeeded(
                         nodes: nodes,
                         format: parameters.format,
+                        preserveVectorData: parameters.preserveVectorData,
                         in: parameters.assets
                     ),
                     self.saveResourceImagesIfNeeded(


### PR DESCRIPTION
Currently Fugen doesn't support setting `Preserve Vector Data` flag for Xcode
assets. This PR adds the ability to change this setting through configuration
file and command line argument.
