### PR TITLE
Added `init(layer: Any)` to `ShadowStyleLayer` to avoid crash when animating

### DIFF
--- a/Demo/FugenDemo/Generated/ShadowStyle.swift
+++ b/Demo/FugenDemo/Generated/ShadowStyle.swift
@@ -274,6 +274,15 @@ open class ShadowStyleLayer: CALayer {
         fatalError("init(coder:) has not been implemented")
     }
 
+    public override init(layer: Any) {
+        if let layer = layer as? ShadowStyleLayer {
+            self.shadowStyle = layer.shadowStyle
+        } else {
+            self.shadowStyle = .clear
+        }
+        super.init(layer: layer)
+    }
+
     // MARK: - Instance Methods
 
     private func configureShadowLayers() {

--- a/Templates/ShadowStyles.stencil
+++ b/Templates/ShadowStyles.stencil
@@ -224,6 +224,15 @@ private extension {{ bezierPathTypeName }} {
         fatalError("init(coder:) has not been implemented")
     }
 
+    {{ accessModifier }} override init(layer: Any) {
+        if let layer = layer as? {{ shadowStyleLayerTypeName }} {
+            self.shadowStyle = layer.shadowStyle
+        } else {
+            self.shadowStyle = .clear
+        }
+        super.init(layer: layer)
+    }
+
     // MARK: - Instance Methods
 
     private func configureShadowLayers() {


### PR DESCRIPTION
When sub classing `CALayer` with custom properties `init(layer: Any)` should be override in order to avoid crash because of uninitialized properties.
https://developer.apple.com/documentation/quartzcore/calayer/1410842-init 