### PR TITLE
Added sort to image asset to avoid `Content.json` changes every run

### DIFF
--- a/Sources/FugenTools/Assets/ImageSet/AssetImageSetContents.swift
+++ b/Sources/FugenTools/Assets/ImageSet/AssetImageSetContents.swift
@@ -17,6 +17,8 @@ public struct AssetImageSetContents: Codable, Hashable {
     ) {
         self.info = info
         self.properties = properties
-        self.images = images
+        self.images = images?.sorted(by: { left, right in
+            left.scale?.rawValue ?? "" <= right.scale?.rawValue ?? ""
+        })
     }
 }


### PR DESCRIPTION
I added this sort because otherwise every time I run the script the `Content.json` of each Image is generated in different order, creating hard to track changes.